### PR TITLE
Use cross-fetch, which is available in Node/jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
         "bootstrap-icons": "^1.9.1",
         "buffer": "^6.0.3",
         "classnames": "^2.3.1",
+        "cross-fetch": "^3.1.5",
         "ed25519-hd-key": "^1.3.0",
         "emoji-mart": "^5.3.3",
         "formik": "^2.2.9",

--- a/src/shared/utils/simpleApiCall.ts
+++ b/src/shared/utils/simpleApiCall.ts
@@ -1,4 +1,5 @@
 import { BASE_URL } from '../constants';
+import { fetch } from 'cross-fetch'
 
 type FetchData = {
     method: string;


### PR DESCRIPTION
Some of our code which hits Ethos servers relies on the browser's native `fetch` call. But in tests, which run in Node (Jest's runtime), `fetch` is not there and blows up with an undefined symbol error.

cross-fetch just goes through to the native `fetch` in a browser, but in Node (which is the env Jest runs in), it goes through to an implemenation called `node-fetch`. 

And because it will now be backed by a real implementation, we can mock responses using `nock`.