### PR TITLE
Inject a "WindowCloser" rather than a Window.

### DIFF
--- a/src/shared/utils/dependenciesContext.tsx
+++ b/src/shared/utils/dependenciesContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+export interface WindowCloser {
+    (): void;
+}
+export interface Dependencies {
+    closeWindow: WindowCloser;
+}
+export const DependenciesContext = createContext<Dependencies | undefined>(
+    undefined
+);
+
+export const useDependencies = (): Dependencies => {
+    const dependencies = useContext(DependenciesContext);
+    if (!dependencies) {
+        throw new Error('Dependencies not found');
+    }
+    return dependencies;
+};

--- a/src/shared/utils/windowContext.tsx
+++ b/src/shared/utils/windowContext.tsx
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export const WindowContext = createContext<Window>(window);

--- a/src/test/utils/react-rendering.tsx
+++ b/src/test/utils/react-rendering.tsx
@@ -6,22 +6,22 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { queryClient } from '_app/helpers/queryClient';
 import { AppType } from '_redux/slices/app/AppType';
+import { DependenciesContext } from '_shared/utils/dependenciesContext';
 import { createStore } from '_store';
 
 import type { PreloadedState } from '@reduxjs/toolkit';
 import type { RenderOptions } from '@testing-library/react';
 import type { RootState } from '_redux/RootReducer';
+import type { Dependencies } from '_shared/utils/dependenciesContext';
 import type { AppStore } from '_store';
 import type React from 'react';
 import type { PropsWithChildren } from 'react';
-import { WindowContext } from '_src/shared/utils/windowContext';
-import { JSDOM } from 'jsdom';
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
     preloadedState?: PreloadedState<RootState>;
     store?: AppStore;
     initialRoute?: string;
-    testWindow?: Window;
+    dependencies?: Dependencies;
 }
 
 export function renderWithProviders(
@@ -31,7 +31,9 @@ export function renderWithProviders(
         // Automatically create a store instance if no store was passed in
         store = createStore({ app: { appType: AppType.fullscreen } }),
         initialRoute,
-        testWindow = new JSDOM().window as unknown as Window,
+        dependencies = {
+            closeWindow: jest.fn(),
+        },
         ...renderOptions
     }: ExtendedRenderOptions = {}
 ) {
@@ -43,9 +45,9 @@ export function renderWithProviders(
                 <Provider store={store}>
                     <IntlProvider locale={'pt'}>
                         <QueryClientProvider client={queryClient}>
-                            <WindowContext.Provider value={testWindow}>
+                            <DependenciesContext.Provider value={dependencies}>
                                 {children}
-                            </WindowContext.Provider>
+                            </DependenciesContext.Provider>
                         </QueryClientProvider>
                     </IntlProvider>
                 </Provider>

--- a/src/ui/app/pages/dapp-tx-approval/index.tsx
+++ b/src/ui/app/pages/dapp-tx-approval/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import truncateMiddle from '../../helpers/truncate-middle';
@@ -25,7 +25,7 @@ import {
     txRequestsSelectors,
 } from '_redux/slices/transaction-requests';
 import { thunkExtras } from '_redux/store/thunk-extras';
-import { WindowContext } from '_shared/utils/windowContext';
+import { useDependencies } from '_shared/utils/dependenciesContext';
 import { MAILTO_SUPPORT_URL } from '_src/shared/constants';
 import UserApproveContainer from '_src/ui/app/components/user-approve-container';
 
@@ -383,15 +383,15 @@ export function DappTxApprovalPage() {
         [dispatch, txRequest]
     );
 
-    const theWindow = useContext(WindowContext);
+    const closeWindow = useDependencies().closeWindow;
 
     useEffect(() => {
         const finished =
             !txRequest || (txRequest && txRequest.approved !== null);
         if (!loading && finished) {
-            theWindow.close();
+            closeWindow();
         }
-    }, [loading, txRequest, theWindow]);
+    }, [loading, txRequest, closeWindow]);
 
     const content: TabSections = useMemo(() => {
         switch (txRequest?.tx.type) {

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -13,8 +13,11 @@ import { growthbook, loadFeatures } from './app/experimentation/feature-gating';
 import { queryClient } from './app/helpers/queryClient';
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
+import { DependenciesContext } from '_shared/utils/dependenciesContext';
 import store from '_store';
 import { thunkExtras } from '_store/thunk-extras';
+
+import type { Dependencies } from '_shared/utils/dependenciesContext';
 
 import './styles/global.scss';
 import './styles/tailwind.css';
@@ -37,18 +40,27 @@ function renderApp() {
         throw new Error('Root element not found');
     }
     const root = createRoot(rootDom);
+
+    const appDependencies: Dependencies = {
+        closeWindow: () => {
+            window.close();
+        },
+    };
+
     root.render(
-        <GrowthBookProvider growthbook={growthbook}>
-            <HashRouter>
-                <Provider store={store}>
-                    <IntlProvider locale={navigator.language}>
-                        <QueryClientProvider client={queryClient}>
-                            <App />
-                        </QueryClientProvider>
-                    </IntlProvider>
-                </Provider>
-            </HashRouter>
-        </GrowthBookProvider>
+        <DependenciesContext.Provider value={appDependencies}>
+            <GrowthBookProvider growthbook={growthbook}>
+                <HashRouter>
+                    <Provider store={store}>
+                        <IntlProvider locale={navigator.language}>
+                            <QueryClientProvider client={queryClient}>
+                                <App />
+                            </QueryClientProvider>
+                        </IntlProvider>
+                    </Provider>
+                </HashRouter>
+            </GrowthBookProvider>
+        </DependenciesContext.Provider>
     );
 }
 


### PR DESCRIPTION
Passing in an actual Window via the `useContext` mechanism seems fraught with confusion, since anybody can reference the global `window` at any time, and which in a test environment is actually different than the window that was injected. 

This PR also includes a slightly more generic dependency injection framework. As our tests get more mature, we will likely need to inject test doubles in more and more places. The `Dependencies` object can be expanded as that happens.
