### PR TITLE
Use isomorphic-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "emoji-mart": "^5.4.0",
                 "formik": "^2.2.9",
                 "framer-motion": "^7.6.5",
-                "isomorphic-unfetch": "^3.1.0",
+                "isomorphic-fetch": "^3.0.0",
                 "mitt": "^3.0.0",
                 "react": "^18.2.0",
                 "react-animated-numbers": "^0.14.0",
@@ -103,6 +103,7 @@
                 "ts-node": "^10.9.1",
                 "tsconfig-paths": "^4.0.0",
                 "typescript": "^4.7.4",
+                "unfetch": "^5.0.0",
                 "webpack-cli": "^4.10.0",
                 "webpack-merge": "^5.8.0"
             }
@@ -12438,13 +12439,13 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/isomorphic-unfetch": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+        "node_modules/isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
             "dependencies": {
                 "node-fetch": "^2.6.1",
-                "unfetch": "^4.2.0"
+                "whatwg-fetch": "^3.4.1"
             }
         },
         "node_modules/isomorphic-ws": {
@@ -21407,9 +21408,10 @@
             }
         },
         "node_modules/unfetch": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+            "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==",
+            "dev": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -21976,8 +21978,7 @@
         "node_modules/whatwg-fetch": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-            "peer": true
+            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
         },
         "node_modules/whatwg-mimetype": {
             "version": "3.0.0",
@@ -31619,13 +31620,13 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
-        "isomorphic-unfetch": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+        "isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
             "requires": {
                 "node-fetch": "^2.6.1",
-                "unfetch": "^4.2.0"
+                "whatwg-fetch": "^3.4.1"
             }
         },
         "isomorphic-ws": {
@@ -38394,9 +38395,10 @@
             }
         },
         "unfetch": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+            "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==",
+            "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -38809,8 +38811,7 @@
         "whatwg-fetch": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-            "peer": true
+            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
         },
         "whatwg-mimetype": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "emoji-mart": "^5.4.0",
         "formik": "^2.2.9",
         "framer-motion": "^7.6.5",
-        "isomorphic-unfetch": "^3.1.0",
+        "isomorphic-fetch": "^3.0.0",
         "mitt": "^3.0.0",
         "react": "^18.2.0",
         "react-animated-numbers": "^0.14.0",

--- a/src/shared/utils/simpleApiCall.ts
+++ b/src/shared/utils/simpleApiCall.ts
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch';
-
 import { BASE_URL } from '../constants';
 
 type FetchData = {

--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// replaces global fetch with something that works in Node (i.e. tests)
+import 'isomorphic-fetch';
 import { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 


### PR DESCRIPTION
We were previously using `isomorphic-unfetch`, [the latest version of which broke both `npm build` and the tests](https://github.com/EthosWallet/chrome-extension/pull/44). This solution seems fine and works with no problems.