### PR TITLE
Negative margin cuts logo off

### DIFF
--- a/src/ui/app/shared/layouts/OnboardingCard.tsx
+++ b/src/ui/app/shared/layouts/OnboardingCard.tsx
@@ -114,7 +114,7 @@ const OnboardingCard = ({
 
     return (
         <>
-            <span className="h-[48px] w-[112px] mb-4 tall:mb-8 -mt-[80px]">
+            <span className="h-[48px] w-[112px] mb-4 tall:mb-8">
                 <EthosLogoGrayscaleWithText />
             </span>
 


### PR DESCRIPTION
Example: 

<img width="684" alt="image" src="https://user-images.githubusercontent.com/6696080/214973299-c527cd60-a3e8-4508-bbe5-cd2e82970f5d.png">
