### PR TITLE
Map the '/' route to an instant redirect.

### DIFF
--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -72,11 +72,11 @@ const App = () => {
         <ThemeProvider initialTheme={undefined}>
             <LockWalletProvider>
                 <Routes>
+                    <Route
+                        path="/"
+                        element={<Navigate to="/tokens" replace={true} />}
+                    />
                     <Route path="/*" element={<HomePage />}>
-                        <Route
-                            index
-                            element={<Navigate to="/tokens" replace={true} />}
-                        />
                         <Route path="tokens" element={<TokensPage />} />
                         <Route path="nfts">
                             <Route path={'*'} element={<NftsPage />} />


### PR DESCRIPTION
Previously we used a nested index route with a <Navigate> element to redirect. Because HomePage wraps the <Outlet/> element in a <Loading> element which does not render until the SuiObjects data comes in, this had the effect of redirecting the '/' to '/tokens' after an indeterminate amount of time. This is unexpected and undesired, we want '/' to redirect immediately.