### PR TITLE
Mockchain improvements

### DIFF
--- a/src/test/EmailAuthentication.integration.test.tsx
+++ b/src/test/EmailAuthentication.integration.test.tsx
@@ -2,13 +2,15 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 
-import { mockSuiObjects, mockCommonCalls } from './utils/mockchain';
+import { mockSuiObjects, Mockchain } from './utils/mockchain';
 import { BASE_URL } from '_src/shared/constants';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('Email Authentication', () => {
+    let mockchain: Mockchain;
     beforeEach(() => {
-        mockCommonCalls();
+        mockchain = new Mockchain();
+        mockchain.mockCommonCalls();
     });
 
     test('User can enter email and is prompted to wait for the magic login link', async () => {

--- a/src/test/GettingStarted.integration.test.tsx
+++ b/src/test/GettingStarted.integration.test.tsx
@@ -1,12 +1,17 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { mockCommonCalls } from '_src/test/utils/mockchain';
+import { Mockchain } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('Authenticating by importing an account with a seed phrase', () => {
+    let mockchain: Mockchain;
+    beforeEach(() => {
+        mockchain = new Mockchain();
+        mockchain.mockCommonCalls();
+    });
+
     test('Entire flow works', async () => {
-        mockCommonCalls();
         const validSeedPhrase =
             'girl empower human spring circle ceiling wild pact stumble model wheel chuckle';
         const seedPhraseList = validSeedPhrase.split(' ');

--- a/src/test/NavBar.integration.test.tsx
+++ b/src/test/NavBar.integration.test.tsx
@@ -2,13 +2,15 @@ import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { simulateAuthenticatedUser } from '_src/test/utils/fake-local-storage';
-import { mockCommonCalls, mockSuiObjects } from '_src/test/utils/mockchain';
+import { Mockchain, mockSuiObjects } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('Top Nav Wallet Management', () => {
+    let mockchain: Mockchain;
     beforeEach(async () => {
+        mockchain = new Mockchain();
         simulateAuthenticatedUser();
-        mockCommonCalls();
+        mockchain.mockCommonCalls();
         mockSuiObjects();
     });
 

--- a/src/test/Security.integration.test.tsx
+++ b/src/test/Security.integration.test.tsx
@@ -8,7 +8,7 @@ import {
     recoveryPhrase,
     simulateAuthenticatedUser,
 } from '_src/test/utils/fake-local-storage';
-import { mockCommonCalls, mockSuiObjects } from '_src/test/utils/mockchain';
+import { Mockchain, mockSuiObjects } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('The Security Settings page', () => {
@@ -32,9 +32,11 @@ describe('The Security Settings page', () => {
         await navigateToSecurity();
     };
 
+    let mockchain: Mockchain;
     beforeEach(async () => {
+        mockchain = new Mockchain();
         simulateAuthenticatedUser();
-        mockCommonCalls();
+        mockchain.mockCommonCalls();
     });
 
     test('requires a valid password to view the recovery phrase', async () => {

--- a/src/test/TokensPage.integration.test.tsx
+++ b/src/test/TokensPage.integration.test.tsx
@@ -1,13 +1,15 @@
 import { screen } from '@testing-library/react';
 
 import { simulateAuthenticatedUser } from '_src/test/utils/fake-local-storage';
-import { mockCommonCalls, mockSuiObjects } from '_src/test/utils/mockchain';
+import { Mockchain, mockSuiObjects } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('Rendering the Tokens page', () => {
+    let mockchain: Mockchain;
     beforeEach(async () => {
+        mockchain = new Mockchain();
         simulateAuthenticatedUser();
-        mockCommonCalls();
+        mockchain.mockCommonCalls();
     });
 
     test('rendering the Tokens page when wallet has no coins', async () => {

--- a/src/test/TransactionApproval.integration.test.tsx
+++ b/src/test/TransactionApproval.integration.test.tsx
@@ -8,7 +8,7 @@ import { BackgroundClient } from '_app/background-client';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
 import { simulateAuthenticatedUser } from '_src/test/utils/fake-local-storage';
 import { renderTemplate } from '_src/test/utils/json-templates';
-import { mockCommonCalls } from '_src/test/utils/mockchain';
+import { Mockchain } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 import { createStore } from '_store';
 import { thunkExtras } from '_store/thunk-extras';
@@ -18,8 +18,10 @@ import type { AppStore } from '_store';
 
 describe('The Transaction Approval popup', () => {
     let store: AppStore;
+    let mockchain: Mockchain;
     beforeEach(async () => {
-        mockCommonCalls();
+        mockchain = new Mockchain();
+        mockchain.mockCommonCalls();
         simulateAuthenticatedUser();
         store = createStore({});
 

--- a/src/test/TransactionHistory.integration.test.tsx
+++ b/src/test/TransactionHistory.integration.test.tsx
@@ -5,14 +5,16 @@ import nock from 'nock';
 
 import { simulateAuthenticatedUser } from '_src/test/utils/fake-local-storage';
 import { renderTemplate } from '_src/test/utils/json-templates';
-import { mockCommonCalls, mockSuiObjects } from '_src/test/utils/mockchain';
+import { Mockchain, mockSuiObjects } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 import { preventActWarning } from '_src/test/utils/test-helpers';
 
 describe('The Transaction History Page', () => {
+    let mockchain: Mockchain;
     beforeEach(async () => {
+        mockchain = new Mockchain();
         simulateAuthenticatedUser();
-        mockCommonCalls();
+        mockchain.mockCommonCalls();
     });
 
     test('Handles a wallet that has no transactions', async () => {

--- a/src/test/WalletUnlock.integration.test.tsx
+++ b/src/test/WalletUnlock.integration.test.tsx
@@ -6,11 +6,14 @@ import {
     simulateAuthenticatedUser,
     simulateLogout,
 } from '_src/test/utils/fake-local-storage';
-import { mockCommonCalls, mockSuiObjects } from '_src/test/utils/mockchain';
+import { Mockchain, mockSuiObjects } from '_src/test/utils/mockchain';
 import { renderApp } from '_src/test/utils/react-rendering';
 
 describe('Unlocking the wallet', () => {
+    let mockchain: Mockchain;
     beforeEach(async () => {
+        mockchain = new Mockchain();
+        mockchain.mockCommonCalls();
         await createLockedWallet();
     });
 
@@ -33,7 +36,6 @@ describe('Unlocking the wallet', () => {
 const createLockedWallet = async () => {
     await simulateAuthenticatedUser();
     await simulateLogout();
-    mockCommonCalls();
     mockSuiObjects();
     renderApp();
     await screen.findAllByText('Unlock Wallet');

--- a/src/test/utils/json-templates.ts
+++ b/src/test/utils/json-templates.ts
@@ -12,6 +12,5 @@ const loadTemplateAsString = function (templateName: string) {
 export function renderTemplate(templateName: string, view: unknown) {
     const templateAsString = loadTemplateAsString(templateName);
     const renderedString = Mustache.render(templateAsString, view);
-    // console.log("renderedString", renderedString)
     return JSON.parse(renderedString);
 }

--- a/src/test/utils/mockchain.ts
+++ b/src/test/utils/mockchain.ts
@@ -22,30 +22,31 @@ export class Mockchain {
             id: uuidV4.toString(),
         });
     }
+
+    mockCommonCalls() {
+        this.mockBlockchainCall(
+            { method: 'rpc.discover' },
+            { info: { version: '0.20.1' } },
+            true
+        );
+
+        const coinMetadataResponse = {
+            decimals: 9,
+            name: 'Sui',
+            symbol: 'SUI',
+            description: '',
+            iconUrl: null,
+            id: null,
+        };
+        this.mockBlockchainCall(
+            { method: 'sui_getCoinMetadata' },
+            coinMetadataResponse,
+            true
+        );
+    }
 }
 
-export const mockCommonCalls = function () {
-    new Mockchain().mockBlockchainCall(
-        { method: 'rpc.discover' },
-        { info: { version: '0.20.1' } },
-        true
-    );
-
-    const coinMetadataResponse = {
-        decimals: 9,
-        name: 'Sui',
-        symbol: 'SUI',
-        description: '',
-        iconUrl: null,
-        id: null,
-    };
-    new Mockchain().mockBlockchainCall(
-        { method: 'sui_getCoinMetadata' },
-        coinMetadataResponse,
-        true
-    );
-};
-
+// TODO: move this over to Mockchain class
 export const mockSuiObjects = function (
     options: {
         coinId?: string;

--- a/src/test/utils/mockchain.ts
+++ b/src/test/utils/mockchain.ts
@@ -6,24 +6,26 @@ import nock from 'nock';
 import { join } from 'path';
 import { renderTemplate } from './json-templates';
 
-export const mockBlockchainCall = function (
-    request: { method: string; params?: any },
-    result: any,
-    persist?: boolean
-) {
-    let theNock = nock('http://devNet-fullnode.example.com');
-    if (persist) {
-        theNock = theNock.persist();
+export class Mockchain {
+    mockBlockchainCall(
+        request: { method: string; params?: any },
+        result: any,
+        persist?: boolean
+    ) {
+        let theNock = nock('http://devNet-fullnode.example.com');
+        if (persist) {
+            theNock = theNock.persist();
+        }
+        theNock.post('/', _.matches(request)).reply(200, {
+            jsonrpc: '2.0',
+            result: result,
+            id: uuidV4.toString(),
+        });
     }
-    theNock.post('/', _.matches(request)).reply(200, {
-        jsonrpc: '2.0',
-        result: result,
-        id: uuidV4.toString(),
-    });
-};
+}
 
 export const mockCommonCalls = function () {
-    mockBlockchainCall(
+    new Mockchain().mockBlockchainCall(
         { method: 'rpc.discover' },
         { info: { version: '0.20.1' } },
         true
@@ -37,7 +39,7 @@ export const mockCommonCalls = function () {
         iconUrl: null,
         id: null,
     };
-    mockBlockchainCall(
+    new Mockchain().mockBlockchainCall(
         { method: 'sui_getCoinMetadata' },
         coinMetadataResponse,
         true

--- a/src/test/utils/mockchain.ts
+++ b/src/test/utils/mockchain.ts
@@ -1,31 +1,47 @@
 import { readFileSync } from 'fs';
+import _ from 'lodash';
+import { v4 as uuidV4 } from 'uuid';
+
 import nock from 'nock';
 import { join } from 'path';
 import { renderTemplate } from './json-templates';
 
+export const mockBlockchainCall = function (
+    request: { method: string; params?: any },
+    result: any,
+    persist?: boolean
+) {
+    let theNock = nock('http://devNet-fullnode.example.com');
+    if (persist) {
+        theNock = theNock.persist();
+    }
+    theNock.post('/', _.matches(request)).reply(200, {
+        jsonrpc: '2.0',
+        result: result,
+        id: uuidV4.toString(),
+    });
+};
 
 export const mockCommonCalls = function () {
-    nock('http://devNet-fullnode.example.com')
-        .persist()
-        .post('/', /rpc.discover/)
-        .reply(200, {
-            jsonrpc: '2.0',
-            result: { info: { version: '0.20.1' } },
-            id: 'fbf9bf0c-a3c9-460a-a999-b7e87096dd1c',
-        })
-        .post('/', /sui_getCoinMetadata/)
-        .reply(200, {
-            jsonrpc: '2.0',
-            result: {
-                decimals: 9,
-                name: 'Sui',
-                symbol: 'SUI',
-                description: '',
-                iconUrl: null,
-                id: null,
-            },
-            id: 'fbf9bf0c-a3c9-460a-a999-b7e87096dd1c',
-        });
+    mockBlockchainCall(
+        { method: 'rpc.discover' },
+        { info: { version: '0.20.1' } },
+        true
+    );
+
+    const coinMetadataResponse = {
+        decimals: 9,
+        name: 'Sui',
+        symbol: 'SUI',
+        description: '',
+        iconUrl: null,
+        id: null,
+    };
+    mockBlockchainCall(
+        { method: 'sui_getCoinMetadata' },
+        coinMetadataResponse,
+        true
+    );
 };
 
 export const mockSuiObjects = function (
@@ -50,13 +66,13 @@ export const mockSuiObjects = function (
         renderedObjects.push(renderedNftResult);
     }
 
-    const renderedResponses = renderedObjects.map(
-        (value) => {
-            return {jsonrpc: "2.0", id: "fbf9bf0c-a3c9-460a-a999-b7e87096dd1c", result: value}
-        }
-    );
-    // const finalRenderedTemplate = `[${renderedResponses.join(',')}]`;
-
+    const renderedResponses = renderedObjects.map((value) => {
+        return {
+            jsonrpc: '2.0',
+            id: 'fbf9bf0c-a3c9-460a-a999-b7e87096dd1c',
+            result: value,
+        };
+    });
     // TODO: make this work for both wallets that are in play for the user (see fake-local-storage).
 
     // TODO: clean this up.  in the case where renderedResponses is an empty array (i.e. fresh wallet with nothing in


### PR DESCRIPTION
Refactors mockchain.ts to export a class (`Mockchain`) for tests to interact with. Moves some of the code in `mockchain.ts` over to the class. 

Lots more to be done here:
- move `mockSuiObjects` into `Mockchain`
- make `mockBlockchainCall` smart enough to automatically mock out multiple JsonRPC requests in the same HTTP request
- convenience method to add an object/transaction (since adding either by themselves sets up an inconsistent blockchain state)