### PR TITLE
Move locked key to session storage

### DIFF
--- a/src/background/Transactions.ts
+++ b/src/background/Transactions.ts
@@ -442,6 +442,11 @@ class Transactions {
     }
 
     private async getAccount(address: SuiAddress): Promise<AccountInfo> {
+        // TODO: this checked for the wallet being locked seems buggy. it doesn't pass
+        // the passphrase, so it will never pull the right value out of storage (it will
+        // always be null). But also the existence of the 'locked' key actually means the
+        // wallet is *unlocked*, so the logic here is backwards.
+        // linear ticket here: https://linear.app/ethoswallet/issue/ETHOS-630/preapprovals-should-not-go-through-once-wallet-is-locked
         const locked = await getEncrypted({ key: 'locked', session: false });
         const passphrase = await getEncrypted({
             key: 'passphrase',
@@ -452,6 +457,7 @@ class Transactions {
             session: true,
         });
         if (locked || (!passphrase && !authentication)) {
+            // TODO: should we really throw an error with the passphrase printed out?
             throw new Error(
                 `Wallet is locked: ${locked} ${passphrase} ${authentication}`
             );

--- a/src/background/Transactions.ts
+++ b/src/background/Transactions.ts
@@ -17,6 +17,7 @@ import { Window } from './Window';
 import { API_ENV } from '../ui/app/ApiProvider';
 import { PREAPPROVAL_KEY, TX_STORE_KEY } from '_src/shared/constants';
 import { getEncrypted, setEncrypted } from '_src/shared/storagex/store';
+import { isLocked } from '_src/ui/app/helpers/lock-wallet';
 import { api } from '_src/ui/app/redux/store/thunk-extras';
 
 import type {
@@ -43,7 +44,7 @@ import type { TransactionRequestResponse } from '_payloads/transactions/ui/Trans
 import type { ContentScriptConnection } from '_src/background/connections/ContentScriptConnection';
 import type { Preapproval } from '_src/shared/messaging/messages/payloads/transactions/Preapproval';
 import type { AccountInfo } from '_src/ui/app/KeypairVault';
-import { isLocked } from '_src/ui/app/helpers/lock-wallet';
+
 
 // type SimpleCoin = {
 //     balance: number;

--- a/src/background/connections/ContentScriptConnection.ts
+++ b/src/background/connections/ContentScriptConnection.ts
@@ -252,6 +252,11 @@ export class ContentScriptConnection extends Connection {
     }
 
     private async getAccountInfos(): Promise<AccountInfo[]> {
+        // TODO: this checked for the wallet being locked seems buggy. it doesn't pass
+        // the passphrase, so it will never pull the right value out of storage (it will
+        // always be null). But also the existence of the 'locked' key actually means the
+        // wallet is *unlocked*, so the logic here is backwards.
+        // linear ticket here: https://linear.app/ethoswallet/issue/ETHOS-630/preapprovals-should-not-go-through-once-wallet-is-locked
         const locked = await getEncrypted({ key: 'locked', session: false });
         if (locked) {
             throw new Error('Wallet is locked');

--- a/src/background/connections/ContentScriptConnection.ts
+++ b/src/background/connections/ContentScriptConnection.ts
@@ -4,6 +4,7 @@
 import { Connection } from './Connection';
 import { DEFAULT_API_ENV } from '../../ui/app/ApiProvider';
 import Authentication from '../Authentication';
+import { isLocked } from '_app/helpers/lock-wallet';
 import { createMessage } from '_messages';
 import { isGetAccount } from '_payloads/account/GetAccount';
 import {
@@ -44,7 +45,7 @@ import type { GetNetworkResponse } from '_src/shared/messaging/messages/payloads
 import type { DisconnectResponse } from '_src/shared/messaging/messages/payloads/connections/DisconnectResponse';
 import type { OpenWalletResponse } from '_src/shared/messaging/messages/payloads/url/OpenWalletResponse';
 import type { Runtime } from 'webextension-polyfill';
-import { isLocked } from '_app/helpers/lock-wallet';
+
 
 export class ContentScriptConnection extends Connection {
     public static readonly CHANNEL: PortChannelName =

--- a/src/test/utils/storage.ts
+++ b/src/test/utils/storage.ts
@@ -2,6 +2,7 @@ import { deleteEncrypted, setEncrypted } from '_shared/storagex/store';
 import { PERMISSIONS_STORAGE_KEY } from '_src/background/Permissions';
 import { PASSPHRASE_TEST, PREAPPROVAL_KEY } from '_src/shared/constants';
 import { type Permission } from '_src/shared/messaging/messages/payloads/permissions';
+import { setLocked, setUnlocked } from '_app/helpers/lock-wallet';
 
 export const password = 'Password';
 export const recoveryPhrase =
@@ -55,12 +56,7 @@ export const simulateMnemonicUser = async function () {
         session: false,
         passphrase: password,
     });
-    await setEncrypted({
-        key: 'locked',
-        value: `locked${password}`,
-        session: false,
-        passphrase: password,
-    });
+    await setUnlocked(password);
 };
 
 export const simulateEmailUser = async function () {
@@ -79,11 +75,7 @@ export const simulateEmailUser = async function () {
 };
 
 export const simulateLogout = async function () {
-    await deleteEncrypted({
-        key: 'locked',
-        session: false,
-        passphrase: password,
-    });
+    await setLocked(password);
 };
 
 export const simulateConnectedApps = async function () {

--- a/src/ui/app/helpers/lock-wallet.ts
+++ b/src/ui/app/helpers/lock-wallet.ts
@@ -1,12 +1,13 @@
 import Browser from 'webextension-polyfill';
 
-import { WALLET_LOCK_TIMEOUT_MS } from '_src/shared/constants';
 import {
     deleteEncrypted,
     getEncrypted,
     setEncrypted,
 } from '_shared/storagex/store';
-import { LOCKED } from '_redux/slices/account';
+import { WALLET_LOCK_TIMEOUT_MS } from '_src/shared/constants';
+
+const LOCKED = 'locked';
 
 export const resetWalletLockTimer = () => {
     Browser.storage.local.set({

--- a/src/ui/app/helpers/lock-wallet.ts
+++ b/src/ui/app/helpers/lock-wallet.ts
@@ -25,19 +25,19 @@ export const setUnlocked = async (passphrase: string) => {
     await setEncrypted({
         key: LOCKED,
         value: `${LOCKED}${passphrase}`,
-        session: false,
+        session: true,
         passphrase,
     });
 };
 
 export const setLocked = async (passphrase: string) => {
-    await deleteEncrypted({ key: LOCKED, session: false, passphrase });
+    await deleteEncrypted({ key: LOCKED, session: true, passphrase });
 };
 
 export const isLocked = async (passphrase: string) => {
     const unlocked = await getEncrypted({
         key: LOCKED,
-        session: false,
+        session: true,
         passphrase,
     });
 

--- a/src/ui/app/helpers/lock-wallet.ts
+++ b/src/ui/app/helpers/lock-wallet.ts
@@ -7,7 +7,7 @@ import {
 } from '_shared/storagex/store';
 import { WALLET_LOCK_TIMEOUT_MS } from '_src/shared/constants';
 
-const LOCKED = 'locked';
+const UNLOCKED = 'unlocked';
 
 export const resetWalletLockTimer = () => {
     Browser.storage.local.set({
@@ -23,23 +23,23 @@ export const startWalletLockTimer = () => {
 
 export const setUnlocked = async (passphrase: string) => {
     await setEncrypted({
-        key: LOCKED,
-        value: `${LOCKED}${passphrase}`,
+        key: UNLOCKED,
+        value: `${UNLOCKED}${passphrase}`,
         session: true,
         passphrase,
     });
 };
 
 export const setLocked = async (passphrase: string) => {
-    await deleteEncrypted({ key: LOCKED, session: true, passphrase });
+    await deleteEncrypted({ key: UNLOCKED, session: true, passphrase });
 };
 
 export const isLocked = async (passphrase: string) => {
     const unlocked = await getEncrypted({
-        key: LOCKED,
+        key: UNLOCKED,
         session: true,
         passphrase,
     });
 
-    return !unlocked || unlocked !== `${LOCKED}${passphrase}`;
+    return !unlocked || unlocked !== `${UNLOCKED}${passphrase}`;
 };

--- a/src/ui/app/helpers/lock-wallet.ts
+++ b/src/ui/app/helpers/lock-wallet.ts
@@ -1,6 +1,12 @@
 import Browser from 'webextension-polyfill';
 
 import { WALLET_LOCK_TIMEOUT_MS } from '_src/shared/constants';
+import {
+    deleteEncrypted,
+    getEncrypted,
+    setEncrypted,
+} from '_shared/storagex/store';
+import { LOCKED } from '_redux/slices/account';
 
 export const resetWalletLockTimer = () => {
     Browser.storage.local.set({
@@ -12,4 +18,27 @@ export const startWalletLockTimer = () => {
     Browser.storage.local.set({
         lockWalletOnTimestamp: Date.now() + WALLET_LOCK_TIMEOUT_MS,
     });
+};
+
+export const setUnlocked = async (passphrase: string) => {
+    await setEncrypted({
+        key: LOCKED,
+        value: `${LOCKED}${passphrase}`,
+        session: false,
+        passphrase,
+    });
+};
+
+export const setLocked = async (passphrase: string) => {
+    await deleteEncrypted({ key: LOCKED, session: false, passphrase });
+};
+
+export const isLocked = async (passphrase: string) => {
+    const unlocked = await getEncrypted({
+        key: LOCKED,
+        session: false,
+        passphrase,
+    });
+
+    return !unlocked || unlocked !== `${LOCKED}${passphrase}`;
 };

--- a/src/ui/app/redux/slices/account/index.ts
+++ b/src/ui/app/redux/slices/account/index.ts
@@ -10,6 +10,7 @@ import {
 import { api, type AppThunkConfig } from '../../store/thunk-extras';
 import { NFT } from '../sui-objects/NFT';
 import { Ticket } from '../sui-objects/Ticket';
+import { isLocked, setLocked, setUnlocked } from '_app/helpers/lock-wallet';
 import {
     clearForNetworkOrWalletSwitch,
     suiObjectsAdapterSelectors,
@@ -33,7 +34,6 @@ import type { SuiAddress, SuiMoveObject } from '@mysten/sui.js';
 import type { AsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '_redux/RootReducer';
 import type { AccountInfo } from '_src/ui/app/KeypairVault';
-import { isLocked, setLocked, setUnlocked } from '_app/helpers/lock-wallet';
 
 export enum AccountType {
     EMAIL = 'EMAIL',

--- a/src/ui/app/redux/slices/account/index.ts
+++ b/src/ui/app/redux/slices/account/index.ts
@@ -51,8 +51,6 @@ type InitialAccountInfo = {
     accountType: AccountType;
 };
 
-export const LOCKED = 'locked';
-
 export const loadAccountInformationFromStorage = createAsyncThunk(
     'account/loadAccountInformation',
     async (_args, { getState }): Promise<InitialAccountInfo> => {

--- a/src/ui/app/redux/slices/account/index.ts
+++ b/src/ui/app/redux/slices/account/index.ts
@@ -33,6 +33,7 @@ import type { SuiAddress, SuiMoveObject } from '@mysten/sui.js';
 import type { AsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '_redux/RootReducer';
 import type { AccountInfo } from '_src/ui/app/KeypairVault';
+import { isLocked, setLocked, setUnlocked } from '_app/helpers/lock-wallet';
 
 export enum AccountType {
     EMAIL = 'EMAIL',
@@ -168,15 +169,10 @@ export const loadAccountInformationFromStorage = createAsyncThunk(
         } = getState() as RootState;
 
         if (alreadyLocked) {
-            await deleteEncrypted({ key: LOCKED, session: false, passphrase });
+            await setLocked(passphrase);
         }
 
-        const locked = await getEncrypted({
-            key: LOCKED,
-            session: false,
-            passphrase,
-        });
-        if (!locked || locked !== `${LOCKED}${passphrase}`) {
+        if (await isLocked(passphrase)) {
             return {
                 authentication: null,
                 passphrase: passphrase || null,
@@ -392,13 +388,8 @@ export const changePassword: AsyncThunk<
             session: true,
         });
 
-        await deleteEncrypted({ key: LOCKED, session: false });
-        await setEncrypted({
-            key: LOCKED,
-            value: `${LOCKED}${newPassword}`,
-            session: false,
-            passphrase: newPassword,
-        });
+        await setLocked(currentPassword);
+        await setUnlocked(newPassword);
 
         return true;
     }
@@ -435,12 +426,7 @@ export const savePassphrase: AsyncThunk<
             session: false,
         });
 
-        await setEncrypted({
-            key: LOCKED,
-            value: `${LOCKED}${passphrase}`,
-            session: false,
-            passphrase,
-        });
+        await setUnlocked(passphrase);
 
         const {
             account: { mnemonic },
@@ -510,7 +496,7 @@ export const logout = createAsyncThunk(
         if (authentication) {
             await deleteEncrypted({ key: 'authentication', session: true });
         } else if (passphrase) {
-            await deleteEncrypted({ key: LOCKED, session: false, passphrase });
+            await setLocked(passphrase);
         }
     }
 );
@@ -551,12 +537,7 @@ export const unlock: AsyncThunk<string | null, string | null, AppThunkConfig> =
                         session: true,
                     });
 
-                    await setEncrypted({
-                        key: LOCKED,
-                        value: `${LOCKED}${passphrase}`,
-                        session: false,
-                        passphrase,
-                    });
+                    setUnlocked(passphrase);
                     return passphrase;
                 }
             }


### PR DESCRIPTION
Also clean up some buggy code that was checking to see if wallet is locked. 

Plus changed storage key name from 'locked' to 'unlocked'. This means anybody who gets the new chrome extension will find the wallet locked.  

Plus lots of refactoring.