### PR TITLE
Tests now get a fresh QueryClient for each test run.

### DIFF
--- a/src/test/utils/react-rendering.tsx
+++ b/src/test/utils/react-rendering.tsx
@@ -1,4 +1,4 @@
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { API_ENV } from '../../ui/app/ApiProvider';
 import KeypairVault from '_app/KeypairVault';
 import { BackgroundClient } from '_app/background-client';
-import { queryClient } from '_app/helpers/queryClient';
+import { queryConfig } from '_src/ui/app/helpers/queryConfig';
 import App from '_app/index';
 import { AppType } from '_redux/slices/app/AppType';
 import { DependenciesContext } from '_shared/utils/dependenciesContext';
@@ -62,7 +62,9 @@ export async function renderApp({
                 >
                     <Provider store={storeToUse}>
                         <IntlProvider locale={locale}>
-                            <QueryClientProvider client={queryClient}>
+                            <QueryClientProvider
+                                client={new QueryClient(queryConfig)}
+                            >
                                 <DependenciesContext.Provider
                                     value={dependencies}
                                 >

--- a/src/test/utils/storage.ts
+++ b/src/test/utils/storage.ts
@@ -13,13 +13,17 @@ export const password = 'Password';
 export const recoveryPhrase =
     'girl empower human spring circle ceiling wild pact stumble model wheel chuckle';
 
+export const wallet1Address =
+    '0xff263a941b9650b51207a674d59728f6f34102d366f4df5a59514bc3668602de';
+export const wallet2Address =
+    '0x4a3086b9f28f10a6e82b152581db1c792a4183723766b2b291fa49a13a9de3f7';
+
 export const accountInfos = [
     {
         index: 0,
         name: 'Wallet 1',
         color: '#7E23CA',
-        address:
-            '0xff263a941b9650b51207a674d59728f6f34102d366f4df5a59514bc3668602de',
+        address: wallet1Address,
         privateKey:
             '138,218,84,37,236,236,197,76,166,86,150,23,223,51,107,198,3,149,112,132,37,250,167,223,74,224,28,199,243,20,181,211',
     },
@@ -27,8 +31,7 @@ export const accountInfos = [
         index: 1,
         name: 'Wallet 2',
         color: '#2eca23',
-        address:
-            '0x4a3086b9f28f10a6e82b152581db1c792a4183723766b2b291fa49a13a9de3f7',
+        address: wallet2Address,
         privateKey:
             '39,152,242,153,62,243,130,133,194,63,255,73,56,234,127,189,45,66,228,56,187,248,98,49,146,17,246,230,110,0,222,26',
     },

--- a/src/ui/app/ApiProvider.ts
+++ b/src/ui/app/ApiProvider.ts
@@ -3,10 +3,10 @@
 
 import { Connection, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 
-import { queryClient } from './helpers/queryClient';
 import { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 
 import type { Keypair, SuiAddress } from '@mysten/sui.js';
+import type { QueryClient } from '@tanstack/react-query';
 
 export enum API_ENV {
     mainNet = 'mainNet',
@@ -155,13 +155,15 @@ export default class ApiProvider {
     public setNewJsonRpcProvider(
         apiEnv: API_ENV = DEFAULT_API_ENV,
         fallbackNumber?: number,
-        customRPC?: string | null
+        customRPC?: string | null,
+        queryClient?: QueryClient
     ) {
         this._apiEnv = apiEnv;
         this.fallbackNumber = fallbackNumber;
         this._customRPC = customRPC ?? null;
-        // We also clear the query client whenever set set a new API provider:
-        queryClient.clear();
+
+        // Make sure that state is cleared when switching networks
+        queryClient?.clear();
 
         const connection = customRPC
             ? new Connection({ fullnode: customRPC })

--- a/src/ui/app/components/network-selector/custom-rpc-input/index.tsx
+++ b/src/ui/app/components/network-selector/custom-rpc-input/index.tsx
@@ -12,6 +12,7 @@ import { setCustomRPC } from '_redux/slices/app';
 import Button from '_src/ui/app/shared/buttons/Button';
 
 import st from '../NetworkSelector.module.scss';
+import { useQueryClient } from '@tanstack/react-query';
 
 const MIN_CHAR = 5;
 
@@ -40,9 +41,10 @@ export function CustomRPCInput() {
 
     const dispatch = useAppDispatch();
 
+    const queryClient = useQueryClient();
     const changeNetwork = useCallback(
         async ({ rpcInput }: { rpcInput: string }) => {
-            dispatch(setCustomRPC(rpcInput));
+            dispatch(setCustomRPC({ customRPC: rpcInput, queryClient }));
         },
         [dispatch]
     );

--- a/src/ui/app/components/network-selector/index.tsx
+++ b/src/ui/app/components/network-selector/index.tsx
@@ -16,6 +16,7 @@ import { useAppSelector, useAppDispatch } from '_hooks';
 import { changeRPCNetwork } from '_redux/slices/app';
 
 import st from './NetworkSelector.module.scss';
+import { useQueryClient } from '@tanstack/react-query';
 
 const NetworkSelector = () => {
     const [selectedApiEnv, customRPC] = useAppSelector(({ app }) => [
@@ -43,6 +44,8 @@ const NetworkSelector = () => {
         }));
     }, []);
 
+    const queryClient = useQueryClient();
+
     const changeNetwork = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             const networkName = e.currentTarget.dataset.network;
@@ -59,7 +62,7 @@ const NetworkSelector = () => {
                 return;
             }
             const apiEnv = API_ENV[networkName as keyof typeof API_ENV];
-            dispatch(changeRPCNetwork(apiEnv));
+            dispatch(changeRPCNetwork({ apiEnv, queryClient }));
         },
         [customRPC, dispatch]
     );

--- a/src/ui/app/components/settings-menu/subpages/network/CustomRpcForm.tsx
+++ b/src/ui/app/components/settings-menu/subpages/network/CustomRpcForm.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Form, Formik, useField } from 'formik';
 import { useCallback, useMemo } from 'react';
 import * as Yup from 'yup';
@@ -61,11 +62,12 @@ const CustomRpcForm = () => {
 
     const dispatch = useAppDispatch();
 
+    const queryClient = useQueryClient();
     const _onSubmit = useCallback(
         ({ networkUrl }: FormikValues) => {
-            dispatch(setCustomRPC(networkUrl));
+            dispatch(setCustomRPC({ customRPC: networkUrl, queryClient }));
         },
-        [dispatch]
+        [dispatch, queryClient]
     );
     return (
         <div>

--- a/src/ui/app/components/settings-menu/subpages/network/NetworkPage.tsx
+++ b/src/ui/app/components/settings-menu/subpages/network/NetworkPage.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
 import CustomRpcForm from './CustomRpcForm';
@@ -44,6 +45,8 @@ function NetworkPage() {
         }));
     }, []);
 
+    const queryClient = useQueryClient();
+
     const networkOptions = useMemo(() => {
         const options: SegmentedControlItem[] = [];
         networks.forEach((network) => {
@@ -63,7 +66,7 @@ function NetworkPage() {
                     return;
                 }
                 const apiEnv = API_ENV[name as keyof typeof API_ENV];
-                dispatch(changeRPCNetwork(apiEnv));
+                dispatch(changeRPCNetwork({ apiEnv, queryClient }));
             };
             const isCustomRpc = network.name === 'Custom RPC URL';
             const isCustomRpcSelected =
@@ -77,7 +80,7 @@ function NetworkPage() {
             });
         });
         return options;
-    }, [networks, selectedNetworkName, customRPC, dispatch]);
+    }, [networks, selectedNetworkName, customRPC, dispatch, queryClient]);
 
     return (
         <div className="flex flex-col">

--- a/src/ui/app/helpers/queryConfig.ts
+++ b/src/ui/app/helpers/queryConfig.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { QueryClient } from '@tanstack/react-query';
-
-export const queryClient = new QueryClient({
+export const queryConfig = {
     defaultOptions: {
         queries: {
             // Only retry once by default:
@@ -15,4 +13,4 @@ export const queryClient = new QueryClient({
             refetchIntervalInBackground: false,
         },
     },
-});
+};

--- a/src/ui/app/pages/dapp-tx-approval/errors/IncorrectChain.tsx
+++ b/src/ui/app/pages/dapp-tx-approval/errors/IncorrectChain.tsx
@@ -3,6 +3,7 @@ import {
     SUI_MAINNET_CHAIN,
     SUI_TESTNET_CHAIN,
 } from '@mysten/wallet-standard';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { API_ENV } from '_src/ui/app/ApiProvider';
@@ -30,6 +31,7 @@ const IncorrectChain = ({
 }: IncorrectSignerProps) => {
     const dispatch = useAppDispatch();
 
+    const queryClient = useQueryClient();
     const switchChain = useCallback(async () => {
         let correctNetwork;
         switch (correctChain) {
@@ -48,8 +50,10 @@ const IncorrectChain = ({
             default:
                 correctNetwork = API_ENV.mainNet;
         }
-        await dispatch(changeRPCNetwork(correctNetwork));
-    }, [dispatch, correctChain]);
+        await dispatch(
+            changeRPCNetwork({ apiEnv: correctNetwork, queryClient })
+        );
+    }, [dispatch, correctChain, queryClient]);
 
     return (
         <div className="px-6 pb-6 flex flex-col gap-6 items-start justify-start">

--- a/src/ui/app/redux/slices/app/index.ts
+++ b/src/ui/app/redux/slices/app/index.ts
@@ -11,6 +11,7 @@ import { fetchAllOwnedAndRequiredObjects } from '_redux/slices/sui-objects';
 // import { getTransactionsByAddress } from '_redux/slices/txresults';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
+import type { QueryClient } from '@tanstack/react-query';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
 type AppState = {
@@ -43,11 +44,15 @@ export const getRPCNetwork = createAsyncThunk<API_ENV, void, AppThunkConfig>(
 
 // On network change, set setNewJsonRpcProvider, fetch all owned objects, and fetch all transactions
 // TODO: add clear Object state because edge cases where use state stays in cache
-export const changeRPCNetwork = createAsyncThunk<void, API_ENV, AppThunkConfig>(
+export const changeRPCNetwork = createAsyncThunk<
+    void,
+    { apiEnv: API_ENV; queryClient: QueryClient },
+    AppThunkConfig
+>(
     'changeRPCNetwork',
-    (networkName, { extra: { api }, dispatch, getState }) => {
+    ({ apiEnv, queryClient }, { extra: { api }, dispatch, getState }) => {
         const { app } = getState();
-        const isCustomRPC = networkName === API_ENV.customRPC;
+        const isCustomRPC = apiEnv === API_ENV.customRPC;
         const customRPCURL =
             app?.customRPC && isCustomRPC ? app?.customRPC : null;
 
@@ -55,11 +60,11 @@ export const changeRPCNetwork = createAsyncThunk<void, API_ENV, AppThunkConfig>(
         if (isCustomRPC && !customRPCURL) return;
 
         // Set persistent network state
-        Browser.storage.local.set({ sui_Env: networkName });
+        Browser.storage.local.set({ sui_Env: apiEnv });
 
-        dispatch(setApiEnv(networkName));
+        dispatch(setApiEnv(apiEnv));
 
-        api.setNewJsonRpcProvider(networkName, undefined, customRPCURL);
+        api.setNewJsonRpcProvider(apiEnv, undefined, customRPCURL, queryClient);
 
         // dispatch(getTransactionsByAddress());
         dispatch(fetchAllBalances());
@@ -67,41 +72,50 @@ export const changeRPCNetwork = createAsyncThunk<void, API_ENV, AppThunkConfig>(
     }
 );
 
-export const setCustomRPC = createAsyncThunk<void, string, AppThunkConfig>(
-    'setCustomRPC',
-    (customRPC, { dispatch }) => {
-        // Set persistent network state
-        Browser.storage.local.set({ sui_Env_RPC: customRPC });
-        dispatch(setCustomRPCURL(customRPC));
-        dispatch(changeRPCNetwork(API_ENV.customRPC));
-    }
-);
+export const setCustomRPC = createAsyncThunk<
+    void,
+    { customRPC: string; queryClient: QueryClient },
+    AppThunkConfig
+>('setCustomRPC', ({ customRPC, queryClient }, { dispatch }) => {
+    // Set persistent network state
+    Browser.storage.local.set({ sui_Env_RPC: customRPC });
+    dispatch(setCustomRPCURL(customRPC));
+    dispatch(changeRPCNetwork({ apiEnv: API_ENV.customRPC, queryClient }));
+});
 
 export const initNetworkFromStorage = createAsyncThunk<
     void,
-    void,
+    QueryClient,
     AppThunkConfig
->('initNetworkFromStorage', async (_, { dispatch, extra: { api } }) => {
-    const result = await Browser.storage.local.get(['sui_Env', 'sui_Env_RPC']);
+>(
+    'initNetworkFromStorage',
+    async (queryClient, { dispatch, extra: { api } }) => {
+        const result = await Browser.storage.local.get([
+            'sui_Env',
+            'sui_Env_RPC',
+        ]);
 
-    const isValidCustomRPC = result?.sui_Env_RPC?.length > 0;
+        const isValidCustomRPC = result?.sui_Env_RPC?.length > 0;
 
-    const network =
-        result.sui_Env === API_ENV.customRPC && !isValidCustomRPC
-            ? DEFAULT_API_ENV
-            : result.sui_Env;
+        const network =
+            result.sui_Env === API_ENV.customRPC && !isValidCustomRPC
+                ? DEFAULT_API_ENV
+                : result.sui_Env;
 
-    const customRPCURL =
-        network === API_ENV.customRPC && isValidCustomRPC
-            ? result.sui_Env_RPC
-            : null;
+        const customRPCURL =
+            network === API_ENV.customRPC && isValidCustomRPC
+                ? result.sui_Env_RPC
+                : null;
 
-    if (result.sui_Env_RPC && customRPCURL) {
-        dispatch(setCustomRPC(result.sui_Env_RPC));
-    } else if (result.sui_Env) {
-        dispatch(changeRPCNetwork(result.sui_Env));
+        if (result.sui_Env_RPC && customRPCURL) {
+            dispatch(
+                setCustomRPC({ customRPC: result.sui_Env_RPC, queryClient })
+            );
+        } else if (result.sui_Env) {
+            dispatch(changeRPCNetwork({ apiEnv: result.sui_Env, queryClient }));
+        }
     }
-});
+);
 
 const slice = createSlice({
     name: 'app',

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type Root, createRoot } from 'react-dom/client';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
@@ -10,7 +10,7 @@ import { HashRouter } from 'react-router-dom';
 import App from './app';
 import { SuiLedgerClientProvider } from './app/components/ledger/SuiLedgerClientProvider';
 import Loading from './app/components/loading';
-import { queryClient } from './app/helpers/queryClient';
+import { queryConfig } from "_app/helpers/queryConfig";
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
 import { DependenciesContext } from '_shared/utils/dependenciesContext';
@@ -30,16 +30,17 @@ import '_font-icons/output/sui-icons.scss';
 import 'bootstrap-icons/font/bootstrap-icons.scss';
 import 'react-loading-skeleton/dist/skeleton.css';
 
+
 function isDevMode() {
     return process.env.NODE_ENV === 'development';
 }
 
-async function init() {
+async function init(queryClient: QueryClient) {
     if (isDevMode()) {
         Object.defineProperty(window, 'store', { value: store });
     }
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
-    await store.dispatch(initNetworkFromStorage()).unwrap();
+    await store.dispatch(initNetworkFromStorage(queryClient)).unwrap();
     await thunkExtras.background.init(store.dispatch);
 }
 
@@ -78,7 +79,7 @@ function renderTemp() {
     return root;
 }
 
-function renderApp(root: Root) {
+function renderApp(root: Root, queryClient: QueryClient) {
     const rootDom = document.getElementById('root');
     if (!rootDom) {
         throw new Error('Root element not found');
@@ -114,6 +115,7 @@ function renderApp(root: Root) {
 
 (async () => {
     const root = renderTemp();
-    await init();
-    renderApp(root);
+    const queryClient = new QueryClient(queryConfig);
+    await init(queryClient);
+    renderApp(root, queryClient);
 })();


### PR DESCRIPTION
Unfortunately this means we have to pass the QueryClient in a lot of places instead of just reaching out to the global one, which we must do to clear its state.

(we must clear the QueryClient because it holds onto cached data which becomes invalid when the user changes networks)