### PR TITLE
mysten upgrade

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "all",
+      "type": "shell",
+      "command": "npx jest"
+    },
+    {
+      "label": "file",
+      "type": "shell",
+      "command": "npx jest ${file}",
+      "runOptions": {
+        "reevaluateOnRerun": false
+      }
+    },
+    {
+      "label": "line",
+      "type": "shell",
+      "command": "npx jest ${file} -t ${selectedText}",
+      "runOptions": {
+        "reevaluateOnRerun": false
+      }
+    }
+  ]
+}

--- a/src/background/Transactions.ts
+++ b/src/background/Transactions.ts
@@ -6,8 +6,8 @@ import {
     Ed25519Keypair,
     JsonRpcProvider,
     RawSigner,
-    TransactionBlock,
 } from '@mysten/sui.js';
+import { TransactionBlock } from '@mysten/sui.js/transactions';
 import {
     SUI_MAINNET_CHAIN,
     type IdentifierString,
@@ -27,11 +27,8 @@ import { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 import { getEncrypted, setEncrypted } from '_src/shared/storagex/store';
 import { api } from '_src/ui/app/redux/store/thunk-extras';
 
-import type {
-    SignedTransaction,
-    SuiAddress,
-    SuiTransactionBlockResponse,
-} from '@mysten/sui.js';
+import type { SignedTransaction, SuiAddress } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 import type {
     PreapprovalRequest,
     PreapprovalResponse,
@@ -152,12 +149,12 @@ class Transactions {
                 `Transaction failed with the following error. ${txResultError}`
             );
         }
-        if (tx) {
-            if (!txResult || !('digest' in txResult)) {
-                throw new Error(`Transaction result is empty ${txResult}`);
-            }
-            return txResult;
-        }
+        // if (tx) {
+        //     if (!txResult || !('digest' in txResult)) {
+        //         throw new Error(`Transaction result is empty ${txResult}`);
+        //     }
+        //     return txResult;
+        // }
         if (!txSigned) {
             throw new Error('Transaction signature is empty');
         }

--- a/src/ui/app/helpers/getDisplay.ts
+++ b/src/ui/app/helpers/getDisplay.ts
@@ -7,7 +7,10 @@ const getDisplay = (
     if (display?.data && typeof display?.data === 'object') {
         return display.data;
     }
-    if (!('error' in display)) return display;
+
+    // at this point it's truthy (above), has no data (above),
+    // and has no error, so it is the Record
+    if (!('error' in display)) return display as Record<string, string>;
 };
 
 export default getDisplay;

--- a/src/ui/app/helpers/transactions/getTxType.ts
+++ b/src/ui/app/helpers/transactions/getTxType.ts
@@ -1,5 +1,4 @@
-import type { BalanceChange } from './types';
-import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
+import type { BalanceChange, SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 
 export type TxType = string;
 

--- a/src/ui/app/helpers/transactions/types.ts
+++ b/src/ui/app/helpers/transactions/types.ts
@@ -18,24 +18,6 @@ export interface TransactionObjectInfo {
     uri?: string;
 }
 
-export interface BalanceChange {
-    owner:
-        | {
-              AddressOwner: string;
-          }
-        | {
-              ObjectOwner: string;
-          }
-        | {
-              Shared: {
-                  initial_shared_version: number;
-              };
-          }
-        | 'Immutable';
-    coinType: string;
-    amount: string;
-}
-
 export interface HumanReadableTransactionValues {
     timeDisplay?: string;
     image?: ReactNode;

--- a/src/ui/app/redux/slices/account/index.ts
+++ b/src/ui/app/redux/slices/account/index.ts
@@ -1412,6 +1412,7 @@ export const ownedObjects = createSelector(
         if (address) {
             return objects.filter(
                 ({ owner }) =>
+                    owner &&
                     typeof owner === 'object' &&
                     ('ObjectOwner' in owner ||
                         ('AddressOwner' in owner &&

--- a/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -247,6 +247,7 @@ const DisplayDomainRegex =
 export const NftParser: SuiObjectParser<NftRpcResponse, NftRaw> = {
     parser: (data, suiData, rpcResponse) => {
         if (
+            rpcResponse.data &&
             typeof rpcResponse.data === 'object' &&
             'owner' in rpcResponse.data
         ) {

--- a/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/src/ui/app/redux/slices/sui-objects/index.ts
@@ -105,6 +105,7 @@ export const fetchAllOwnedAndRequiredObjects = createAsyncThunk<
                 })
                 .map((anObj) => {
                     if (
+                        anObj.data &&
                         typeof anObj.data === 'object' &&
                         'objectId' in anObj.data
                     ) {


### PR DESCRIPTION
About 10 tests are passing. I picked `format.test.tsx` first and fixed errors until it passed. At the time of stopping I had picked `NavBar.integration.test.tsx` to focus on but only fixed one error. Presumably, after merging this into your branch, you will fail on `transferNFTs.ts`. That one is particularly tricky because it seems they have not re-implemented the helper functions we are relying on. So, the helper functions only accept the old type, while the signer that generates the response object only outputs the new type. I think that trying to force one to output the other will error on type mismatch. 

Potential solutions:

- Perhaps there is a hidden location where those helpers have been defined to work with the new types? I checked the `TransactionBlock` for those methods, but didn't find them. Global search of the sui repo on github didn't reveal any secrets, either.
- Perhaps we could implement those helper functions ourselves? The few I looked at seemed like glorified getters.