### PR TITLE
Ag/sui address to string

### DIFF
--- a/src/background/Permissions.ts
+++ b/src/background/Permissions.ts
@@ -10,7 +10,6 @@ import { BASE_URL, LINK_URL } from '_src/shared/constants';
 import { getEncrypted, setEncrypted } from '_src/shared/storagex/store';
 
 import type { ContentScriptConnection } from './connections/ContentScriptConnection';
-import type { SuiAddress } from '@mysten/sui.js';
 import type {
     Permission,
     PermissionResponse,
@@ -33,7 +32,7 @@ class Permissions {
     public async acquirePermissions(
         permissionTypes: readonly PermissionType[],
         connection: ContentScriptConnection,
-        address: SuiAddress
+        address: string
     ): Promise<Permission> {
         const { origin } = connection;
         const existingPermission = await this.getPermission({ origin });
@@ -227,7 +226,7 @@ class Permissions {
         origin: string,
         permissionTypes: readonly PermissionType[],
         permission?: Permission | null,
-        address?: SuiAddress
+        address?: string
     ): Promise<boolean> {
         if (origin === LINK_URL) return true;
 

--- a/src/background/Transactions.ts
+++ b/src/background/Transactions.ts
@@ -27,7 +27,7 @@ import { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 import { getEncrypted, setEncrypted } from '_src/shared/storagex/store';
 import { api } from '_src/ui/app/redux/store/thunk-extras';
 
-import type { SignedTransaction, SuiAddress } from '@mysten/sui.js';
+import type { SignedTransaction } from '@mysten/sui.js';
 import type { SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 import type {
     PreapprovalRequest,
@@ -172,7 +172,7 @@ class Transactions {
     }: {
         target?: `${string}::${string}::${string}`;
         objectIds?: string[];
-        address?: SuiAddress;
+        address?: string;
         chain?: IdentifierString;
         preapproval?: Preapproval;
     }) {
@@ -199,7 +199,7 @@ class Transactions {
 
     private async tryDirectExecution(
         tx: TransactionBlock,
-        address: SuiAddress,
+        address: string,
         chain: IdentifierString | undefined,
         preapprovalRequest: PreapprovalRequest,
         requestType?: SuiSignAndExecuteTransactionBlockInput['requestType'],
@@ -278,7 +278,7 @@ class Transactions {
         options,
     }: {
         transactionBlock: TransactionBlock;
-        address: SuiAddress;
+        address: string;
         chain?: IdentifierString;
         requestType?: SuiSignAndExecuteTransactionBlockInput['requestType'];
         options?: SuiSignAndExecuteTransactionBlockInput['options'];

--- a/src/background/connections/ContentScriptConnection.ts
+++ b/src/background/connections/ContentScriptConnection.ts
@@ -55,7 +55,6 @@ import getNextWalletColor from '_src/ui/app/helpers/getNextWalletColor';
 import type { NetworkEnvType } from '../NetworkEnv';
 import type {
     SignedTransaction,
-    SuiAddress,
     SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 import type { Message } from '_messages';
@@ -596,7 +595,7 @@ export class ContentScriptConnection extends Connection {
         });
     }
 
-    private async setActiveAccount(address: SuiAddress): Promise<SuiAddress> {
+    private async setActiveAccount(address: string): Promise<string> {
         const accountInfos = await this.getAccountInfos();
         const activeAccount = accountInfos.find((a) => a.address === address);
 
@@ -677,7 +676,7 @@ export class ContentScriptConnection extends Connection {
         );
     }
 
-    private sendAddress(address: SuiAddress, responseForID?: string) {
+    private sendAddress(address: string, responseForID?: string) {
         this.send(
             createMessage<SwitchAccountResponse>(
                 {
@@ -754,7 +753,7 @@ export class ContentScriptConnection extends Connection {
 
     private async ensurePermissions(
         permissions: PermissionType[],
-        account?: SuiAddress
+        account?: string
     ) {
         const existingPermission = await Permissions.getPermission({
             origin: this.origin,

--- a/src/dapp-interface/DAppInterface.ts
+++ b/src/dapp-interface/DAppInterface.ts
@@ -10,7 +10,6 @@ import { ALL_PERMISSION_TYPES } from '_payloads/permissions';
 import { type GetAccountCustomizations } from '_src/shared/messaging/messages/payloads/account/GetAccountCustomizations';
 import { type GetAccountCustomizationsResponse } from '_src/shared/messaging/messages/payloads/account/GetAccountCustomizationsResponse';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { Payload } from '_payloads';
 import type {
     PermissionType,
@@ -97,7 +96,7 @@ export class DAppInterface {
         );
     }
 
-    public switchAccount(address: string): Promise<SuiAddress> {
+    public switchAccount(address: string): Promise<string> {
         return mapToPromise(
             this.send<SwitchAccount, SwitchAccountResponse>({
                 type: 'switch-account',

--- a/src/shared/cryptography/EthosSigner.ts
+++ b/src/shared/cryptography/EthosSigner.ts
@@ -6,16 +6,15 @@ import { simpleApiCall } from '_src/shared/utils/simpleApiCall';
 
 import type {
     SerializedSignature,
-    SuiAddress,
     JsonRpcProvider,
 } from '@mysten/sui.js';
 
 export class EthosSigner extends SignerWithProvider {
     private readonly accessToken: string;
-    private readonly address: SuiAddress;
+    private readonly address: string;
 
     constructor(
-        address: SuiAddress,
+        address: string,
         accessToken: string,
         provider: JsonRpcProvider
     ) {
@@ -24,7 +23,7 @@ export class EthosSigner extends SignerWithProvider {
         this.accessToken = accessToken;
     }
 
-    async getAddress(): Promise<SuiAddress> {
+    async getAddress(): Promise<string> {
         return this.address;
     }
 

--- a/src/shared/cryptography/LedgerAccount.ts
+++ b/src/shared/cryptography/LedgerAccount.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeSuiAddress, type SuiAddress } from '@mysten/sui.js';
+import { normalizeSuiAddress } from '@mysten/sui.js/utils';
 
 export type SerializedLedgerAccount = {
-    address: SuiAddress;
+    address: string;
     derivationPath: string;
     index: number;
     publicKey: string | null;
 };
 
 export class LedgerAccount {
-    readonly address: SuiAddress;
+    readonly address: string;
     readonly derivationPath: string;
     readonly index: number;
     #publicKey: string | null;
@@ -22,7 +22,7 @@ export class LedgerAccount {
         index,
         publicKey,
     }: {
-        address: SuiAddress;
+        address: string;
         derivationPath: string;
         index: number;
         publicKey: string | null;

--- a/src/shared/cryptography/LedgerSigner.ts
+++ b/src/shared/cryptography/LedgerSigner.ts
@@ -4,7 +4,6 @@
 import {
     type SerializedSignature,
     type SignatureScheme,
-    type SuiAddress,
     toSerializedSignature,
     type JsonRpcProvider,
 } from '@mysten/sui.js';
@@ -40,7 +39,7 @@ export class LedgerSigner extends WalletSigner {
         return this.#suiLedgerClient;
     }
 
-    async getAddress(): Promise<SuiAddress> {
+    async getAddress(): Promise<string> {
         const ledgerClient = await this.#initializeSuiLedgerClient();
         const publicKeyResult = await ledgerClient.getPublicKey(
             this.#derivationPath

--- a/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
+++ b/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
@@ -1,7 +1,6 @@
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload } from '_payloads';
 
 export interface GetAccountResponse extends BasePayload {
     type: 'get-account-response';
-    accounts: { address: SuiAddress; publicKey: string | null }[];
+    accounts: { address: string; publicKey: string | null }[];
 }

--- a/src/shared/messaging/messages/payloads/account/GetAccountsResponse.ts
+++ b/src/shared/messaging/messages/payloads/account/GetAccountsResponse.ts
@@ -1,10 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload } from '_payloads';
 
 export interface GetAccountsResponse extends BasePayload {
     type: 'get-accounts-response';
-    accounts: SuiAddress[];
+    accounts: string[];
 }

--- a/src/shared/messaging/messages/payloads/account/SwitchAccount.ts
+++ b/src/shared/messaging/messages/payloads/account/SwitchAccount.ts
@@ -3,12 +3,11 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface SwitchAccount extends BasePayload {
     type: 'switch-account';
-    address: SuiAddress;
+    address: string;
 }
 
 export function isSwitchAccount(payload: Payload): payload is SwitchAccount {

--- a/src/shared/messaging/messages/payloads/account/SwitchAccountResponse.ts
+++ b/src/shared/messaging/messages/payloads/account/SwitchAccountResponse.ts
@@ -1,10 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload } from '_payloads';
 
 export interface SwitchAccountResponse extends BasePayload {
     type: 'switch-account-response';
-    address: SuiAddress;
+    address: string;
 }

--- a/src/shared/messaging/messages/payloads/permissions/Permission.ts
+++ b/src/shared/messaging/messages/payloads/permissions/Permission.ts
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { PermissionType } from './PermissionType';
-import type { SuiAddress } from '@mysten/sui.js';
 
 export interface Permission {
     id: string;
     origin: string;
     favIcon: string | undefined;
     title: string | undefined;
-    accounts: SuiAddress[];
+    accounts: string[];
     allowed: boolean | null;
     permissions: PermissionType[];
     createdDate: string;

--- a/src/shared/messaging/messages/payloads/permissions/PermissionResponse.ts
+++ b/src/shared/messaging/messages/payloads/permissions/PermissionResponse.ts
@@ -3,13 +3,12 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface PermissionResponse extends BasePayload {
     type: 'permission-response';
     id: string;
-    accounts: SuiAddress[];
+    accounts: string[];
     allowed: boolean;
     responseDate: string;
 }

--- a/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
+++ b/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SignedTransaction, SuiAddress } from '@mysten/sui.js';
+import type { SignedTransaction } from '@mysten/sui.js';
 import type { SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 import type {
     IdentifierString,
@@ -12,7 +12,7 @@ import type {
 export type TransactionDataType = {
     type: 'transaction';
     data: string;
-    account: SuiAddress;
+    account: string;
     chain: IdentifierString;
     justSign?: boolean;
     requestType?: SuiSignAndExecuteTransactionBlockInput['requestType'];
@@ -22,7 +22,7 @@ export type TransactionDataType = {
 export type SignMessageDataType = {
     type: 'sign-message';
     message: string;
-    accountAddress: SuiAddress;
+    accountAddress: string;
 };
 
 export type ApprovalRequest = {

--- a/src/shared/messaging/messages/payloads/transactions/Preapproval.ts
+++ b/src/shared/messaging/messages/payloads/transactions/Preapproval.ts
@@ -1,9 +1,9 @@
-import type { ObjectId, SuiAddress } from '@mysten/sui.js';
+import type { ObjectId } from '@mysten/sui.js';
 import type { IdentifierString } from '@wallet-standard/standard';
 
 export interface Preapproval {
     type: 'preapproval';
-    address: SuiAddress;
+    address: string;
     chain: IdentifierString;
     target: string;
     objectId: ObjectId;

--- a/src/shared/messaging/messages/payloads/transactions/SignMessage.ts
+++ b/src/shared/messaging/messages/payloads/transactions/SignMessage.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiAddress } from '@mysten/sui.js';
 import { type SuiSignMessageOutput } from '@mysten/wallet-standard';
 
 import { type BasePayload, isBasePayload } from '../BasePayload';
@@ -11,7 +10,7 @@ export interface SignMessageRequest extends BasePayload {
     type: 'sign-message-request';
     args?: {
         message: string; // base64
-        accountAddress: SuiAddress;
+        accountAddress: string;
     };
     return?: SuiSignMessageOutput;
 }

--- a/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
+++ b/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
@@ -3,13 +3,12 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 import type { NetworkEnvType } from '_src/background/NetworkEnv';
 
 export type WalletStatusChange = {
     network?: NetworkEnvType;
-    accounts?: { address: SuiAddress; publicKey: string | null }[];
+    accounts?: { address: string; publicKey: string | null }[];
 };
 
 export interface WalletStatusChangePayload

--- a/src/shared/utils/customizationsSync/JwtProvider.tsx
+++ b/src/shared/utils/customizationsSync/JwtProvider.tsx
@@ -1,21 +1,20 @@
 import { createContext, useState } from 'react';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { ReactNode } from 'react';
 
 export const JwtContext = createContext<
     [
-        { [address: SuiAddress]: string },
-        (jwt: string, address: SuiAddress) => void
+        { [address: string]: string },
+        (jwt: string, address: string) => void
     ]
 >([{}, () => null]);
 
 export const JwtProvider = ({ children }: { children: ReactNode }) => {
     const [cachedJwt, setCachedJwt] = useState<{
-        [address: SuiAddress]: string;
+        [address: string]: string;
     }>({});
 
-    const setJwtForAddress = (jwt: string, address: SuiAddress) => {
+    const setJwtForAddress = (jwt: string, address: string) => {
         setCachedJwt((prevState) => ({ ...prevState, [address]: jwt }));
     };
 

--- a/src/shared/utils/customizationsSync/getAllCustomizationsFromSeed.ts
+++ b/src/shared/utils/customizationsSync/getAllCustomizationsFromSeed.ts
@@ -4,17 +4,17 @@ import getCustomization from './getCustomization';
 import getJwtWithSigner from './getJwtWithSigner';
 import KeypairVault from '_src/ui/app/KeypairVault';
 
-import type { JsonRpcProvider, SuiAddress } from '@mysten/sui.js';
+import type { JsonRpcProvider } from '@mysten/sui.js';
 import type { AccountCustomization } from '_src/types/AccountCustomization';
 
 export const getAllCustomizationsFromSeed = async (
     mnemonic: string,
     provider: JsonRpcProvider
-): Promise<Record<SuiAddress, AccountCustomization> | 'deleted'> => {
+): Promise<Record<string, AccountCustomization> | 'deleted'> => {
     const keypairVault = new KeypairVault();
     keypairVault.mnemonic = mnemonic;
 
-    const accountCustomizations: Record<SuiAddress, AccountCustomization> = {};
+    const accountCustomizations: Record<string, AccountCustomization> = {};
 
     let walletIndex = 0;
 

--- a/src/shared/utils/customizationsSync/useJwt.tsx
+++ b/src/shared/utils/customizationsSync/useJwt.tsx
@@ -6,8 +6,6 @@ import getJwt from './getJwt';
 import { useSuiLedgerClient } from '_src/ui/app/components/ledger/SuiLedgerClientProvider';
 import { useAppSelector } from '_src/ui/app/hooks';
 
-import type { RawSigner, SuiAddress } from '@mysten/sui.js';
-import type { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 import type { AccountInfo } from '_src/ui/app/KeypairVault';
 
 export const useJwt = () => {
@@ -23,7 +21,7 @@ export const useJwt = () => {
 
     const getCachedJwt = useCallback(
         async (
-            _address?: SuiAddress,
+            _address?: string,
             _accountIndex?: number,
             _accountInfos?: AccountInfo[]
         ) => {

--- a/src/test/utils/faker.ts
+++ b/src/test/utils/faker.ts
@@ -5,7 +5,7 @@ export const faker = {
     preapproval(): Preapproval {
         return {
             type: 'preapproval',
-            address: 'abc', // type: SuiAddress
+            address: 'abc',
             chain: 'abc:123', // type: IdentifierString
             target: 'target',
             objectId: 'abc', // type: ObjectId

--- a/src/types/AccountCustomization.ts
+++ b/src/types/AccountCustomization.ts
@@ -1,5 +1,3 @@
-import type { SuiAddress } from '@mysten/sui.js';
-
 export interface AccountCustomization {
     nickname?: string;
     color?: string;
@@ -13,6 +11,6 @@ export interface AccountCustomization {
 }
 
 export interface AccountCustomizationWithAddress extends AccountCustomization {
-    address: SuiAddress;
+    address: string;
     publicKey: string | null;
 }

--- a/src/ui/app/ApiProvider.ts
+++ b/src/ui/app/ApiProvider.ts
@@ -5,7 +5,7 @@ import { Connection, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 
 import { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 
-import type { Keypair, SuiAddress } from '@mysten/sui.js';
+import type { Keypair } from '@mysten/sui.js';
 import type { QueryClient } from '@tanstack/react-query';
 
 export enum API_ENV {
@@ -227,7 +227,7 @@ export default class ApiProvider {
     }
 
     public getEthosSignerInstance(
-        address: SuiAddress,
+        address: string,
         accessToken: string
     ): EthosSigner {
         if (!this._apiFullNodeProvider) {

--- a/src/ui/app/background-client/index.ts
+++ b/src/ui/app/background-client/index.ts
@@ -17,7 +17,6 @@ import { isGetPreapprovalResponse } from '_src/shared/messaging/messages/payload
 import type {
     SignedMessage,
     SignedTransaction,
-    SuiAddress,
 } from '@mysten/sui.js';
 import type { SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 import type { Message } from '_messages';
@@ -55,7 +54,7 @@ export class BackgroundClient {
 
     public sendPermissionResponse(
         id: string,
-        accounts: SuiAddress[],
+        accounts: string[],
         allowed: boolean,
         responseDate: string
     ) {

--- a/src/ui/app/components/address-input/index.tsx
+++ b/src/ui/app/components/address-input/index.tsx
@@ -8,12 +8,11 @@ import { getSuiAddress } from './nameservice';
 import { SUI_ADDRESS_VALIDATION } from './validation';
 import Input from '../../shared/inputs/Input';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { FieldProps } from 'formik';
 import type { ChangeEventHandler } from 'react';
 
 export interface AddressInputProps<Values>
-    extends FieldProps<SuiAddress, Values> {
+    extends FieldProps<string, Values> {
     disabled?: boolean;
     placeholder?: string;
     className?: string;

--- a/src/ui/app/components/address-input/validation.ts
+++ b/src/ui/app/components/address-input/validation.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidSuiAddress } from '@mysten/sui.js';
+import { isValidSuiAddress } from '@mysten/sui.js/utils';
 import * as Yup from 'yup';
 
 export const SUI_ADDRESS_VALIDATION = Yup.string()

--- a/src/ui/app/components/explorer-link/Explorer.ts
+++ b/src/ui/app/components/explorer-link/Explorer.ts
@@ -3,7 +3,7 @@
 
 import { API_ENV, DEFAULT_API_ENV } from '_app/ApiProvider';
 
-import type { ObjectId, SuiAddress, TransactionDigest } from '@mysten/sui.js';
+import type { ObjectId, TransactionDigest } from '@mysten/sui.js';
 
 const API_ENV_TO_EXPLORER_URL: Record<API_ENV, string | undefined> = {
     [API_ENV.local]: process.env.EXPLORER_URL_LOCAL,
@@ -56,7 +56,7 @@ export class Explorer {
         return url.href;
     }
 
-    public static getAddressUrl(address: SuiAddress, apiEnv: API_ENV) {
+    public static getAddressUrl(address: string, apiEnv: API_ENV) {
         const url = new URL(`/addresses/${address}`, getDefaultUrl(apiEnv));
         const queryParam = API_ENV_TO_EXPLORER_QUERY_PARAM[apiEnv];
         if (queryParam) {

--- a/src/ui/app/components/explorer-link/index.tsx
+++ b/src/ui/app/components/explorer-link/index.tsx
@@ -11,13 +11,13 @@ import { useAppSelector } from '_hooks';
 import { activeAccountSelector } from '_redux/slices/account';
 import { LinkType } from '_src/enums/LinkType';
 
-import type { ObjectId, SuiAddress, TransactionDigest } from '@mysten/sui.js';
+import type { ObjectId, TransactionDigest } from '@mysten/sui.js';
 import type { ReactNode } from 'react';
 
 export type ExplorerLinkProps = (
     | {
           type: ExplorerLinkType.address;
-          address: SuiAddress;
+          address: string;
           useActiveAddress?: false;
       }
     | {

--- a/src/ui/app/components/receipt-card/PrimaryInteraction.tsx
+++ b/src/ui/app/components/receipt-card/PrimaryInteraction.tsx
@@ -14,7 +14,6 @@ import BodyLarge from '../../shared/typography/BodyLarge';
 import CopyBody from '../../shared/typography/CopyBody';
 
 import type { AnalyzedTransaction } from '../../helpers/transactions/analyzeTransactions';
-import type { SuiAddress } from '@mysten/sui.js';
 
 const AvatarItem = ({
     color,
@@ -79,7 +78,7 @@ const WalletAvatarItem = ({
 }: {
     pre: string;
     fullHeader?: string;
-    address: SuiAddress;
+    address: string;
 }) => {
     const wallet = useWalletOrContact(address);
     const { activeAccountIndex, accountInfos } = useAppSelector(

--- a/src/ui/app/helpers/getSigner.ts
+++ b/src/ui/app/helpers/getSigner.ts
@@ -1,5 +1,5 @@
 import { fromHEX } from '@mysten/bcs';
-import { type SuiAddress, type Keypair, type RawSigner } from '@mysten/sui.js';
+import { type Keypair, type RawSigner } from '@mysten/sui.js';
 import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
 
 import { derivationPathForLedger } from '../pages/home/home/dapp/dapps/Ledger/hooks/useDeriveLedgerAccounts';
@@ -15,7 +15,7 @@ import type { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 export const getSigner = async (
     passphrase: string | null,
     accountInfos: AccountInfo[],
-    address: SuiAddress | null,
+    address: string | null,
     authentication: string | null,
     activeAccountIndex: number,
     connectToLedger: () => Promise<SuiLedgerClient>,

--- a/src/ui/app/helpers/sendTokens.ts
+++ b/src/ui/app/helpers/sendTokens.ts
@@ -1,7 +1,6 @@
 import {
     Coin,
     SUI_TYPE_ARG,
-    type SuiAddress,
     type SuiMoveObject,
     TransactionBlock,
 } from '@mysten/sui.js';
@@ -32,7 +31,7 @@ const sendTokens = async ({
     activeAccountIndex: number;
     tokenTypeArg: string;
     amount: bigint;
-    recipientAddress: SuiAddress;
+    recipientAddress: string;
 }) => {
     const signer = await getSigner(
         passphrase,

--- a/src/ui/app/helpers/transactions/analyzeTransactions.ts
+++ b/src/ui/app/helpers/transactions/analyzeTransactions.ts
@@ -1,5 +1,4 @@
 import {
-    type SuiAddress,
     type SuiTransactionBlockResponse,
     getTotalGasUsed,
 } from '@mysten/sui.js';
@@ -30,11 +29,11 @@ export type ImportantTransactionInfo = {
 };
 
 export type AnalyzedTransaction = {
-    owner: SuiAddress;
+    owner: string;
     digest: string;
     timestampMs?: string;
     isSender: boolean;
-    from?: SuiAddress;
+    from?: string;
     totalGasUsed?: bigint;
     ownerBalanceChanges?: Record<string, bigint>;
     important: ImportantTransactionInfo;
@@ -43,7 +42,7 @@ export type AnalyzedTransaction = {
 };
 
 const analyzeTransactions = (
-    ownerAddress: SuiAddress,
+    ownerAddress: string,
     transactions: SuiTransactionBlockResponse[]
 ) => {
     const results: AnalyzedTransaction[] = [];

--- a/src/ui/app/helpers/transactions/faucetTransactionAnalysis.ts
+++ b/src/ui/app/helpers/transactions/faucetTransactionAnalysis.ts
@@ -1,11 +1,11 @@
-import type { SuiAddress, SuiTransactionBlockResponse } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
 
 export type FaucetTransactionInfo = {
     amount: bigint;
 };
 
 const faucetTransactionAnalysis = (
-    ownerAddress: SuiAddress,
+    ownerAddress: string,
     transactionResponse: SuiTransactionBlockResponse
 ) => {
     const analysis: FaucetTransactionInfo | undefined = undefined;

--- a/src/ui/app/helpers/transactions/findBalanceChanges.ts
+++ b/src/ui/app/helpers/transactions/findBalanceChanges.ts
@@ -1,11 +1,11 @@
 import addressOwner from './addressOwner';
 
-import type { SuiAddress, SuiTransactionBlockResponse } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
 
 export type FindBalanceChangeProps = {
     balanceChanges: SuiTransactionBlockResponse['balanceChanges'];
     value?: bigint;
-    ownerAddress?: SuiAddress;
+    ownerAddress?: string;
 };
 
 const findBalanceChanges = ({

--- a/src/ui/app/helpers/transactions/getDisplayImage.tsx
+++ b/src/ui/app/helpers/transactions/getDisplayImage.tsx
@@ -9,7 +9,6 @@ import { getIcon } from '_src/ui/app/helpers/transactions';
 
 import type { AnalyzedTransaction } from './analyzeTransactions';
 import type { TxAction } from './getTxAction';
-import type { SuiAddress } from '@mysten/sui.js';
 import type { ReactNode } from 'react';
 
 export type TxType = string;
@@ -70,7 +69,7 @@ const ObjectIcon = ({
     return <ActionIcon>{getIcon(txAction)}</ActionIcon>;
 };
 
-const StakingIcon = ({ address }: { address: SuiAddress }) => {
+const StakingIcon = ({ address }: { address: string }) => {
     const { data: validators } = useValidatorsWithApy();
     const validator = validators?.[address ?? ''];
 

--- a/src/ui/app/helpers/transactions/sendTransactionAnalysis.ts
+++ b/src/ui/app/helpers/transactions/sendTransactionAnalysis.ts
@@ -1,5 +1,4 @@
 import {
-    type SuiAddress,
     type SuiTransactionBlockResponse,
     getTotalGasUsed,
 } from '@mysten/sui.js';
@@ -9,8 +8,8 @@ import findBalanceChanges from './findBalanceChanges';
 
 export type SendTransactionInfo = {
     isSender: boolean;
-    sender: SuiAddress;
-    recipient: SuiAddress;
+    sender: string;
+    recipient: string;
     coinType?: string;
     coinAmount?: bigint;
     objectId?: string;
@@ -18,7 +17,7 @@ export type SendTransactionInfo = {
 };
 
 const sendTransactionAnalysis = (
-    ownerAddress: SuiAddress,
+    ownerAddress: string,
     transactionResponse: SuiTransactionBlockResponse
 ) => {
     const analysis: SendTransactionInfo[] = [];

--- a/src/ui/app/helpers/transactions/stakingTransactionAnalysis.ts
+++ b/src/ui/app/helpers/transactions/stakingTransactionAnalysis.ts
@@ -1,5 +1,4 @@
 import {
-    type SuiAddress,
     type SuiTransactionBlockResponse,
     type SuiJsonValue,
     getTotalGasUsed,
@@ -15,7 +14,7 @@ export type StakingTransactionInfo = {
 };
 
 const stakingTransactionAnalysis = (
-    ownerAddress: SuiAddress,
+    ownerAddress: string,
     transaction: SuiTransactionBlockResponse
 ) => {
     const analysis: StakingTransactionInfo[] = [];

--- a/src/ui/app/helpers/transferNFT.ts
+++ b/src/ui/app/helpers/transferNFT.ts
@@ -1,11 +1,6 @@
 import {
-    type SuiAddress,
     type JsonRpcProvider,
     TransactionBlock,
-    getTimestampFromTransactionResponse,
-    getExecutionStatusType,
-    getTotalGasUsed,
-    getTransactionDigest,
 } from '@mysten/sui.js';
 
 import { getSigner } from './getSigner';
@@ -34,7 +29,7 @@ const transferNFT = async ({
     address: string | null;
     authentication: string | null;
     activeAccountIndex: number;
-    recipientAddress: SuiAddress;
+    recipientAddress: string;
     provider: JsonRpcProvider;
 }) => {
     if (!nft) return;

--- a/src/ui/app/helpers/transferObjectTransactionBlock.ts
+++ b/src/ui/app/helpers/transferObjectTransactionBlock.ts
@@ -1,6 +1,5 @@
 import type {
     JsonRpcProvider,
-    SuiAddress,
     TransactionBlock,
 } from '@mysten/sui.js';
 import type { ExtendedSuiObjectData } from '_redux/slices/sui-objects';
@@ -12,7 +11,7 @@ const kioskModule = '0x2::kiosk';
 const transferObjectTransactionBlock = async (
     transactionBlock: TransactionBlock,
     object: ExtendedSuiObjectData,
-    recipient: SuiAddress,
+    recipient: string,
     provider: JsonRpcProvider
 ) => {
     if (!object.kiosk?.type) {

--- a/src/ui/app/hooks/staking/useValidatorsWithApy.ts
+++ b/src/ui/app/hooks/staking/useValidatorsWithApy.ts
@@ -1,4 +1,4 @@
-import { type SuiAddress, type SuiValidatorSummary } from '@mysten/sui.js';
+import { type SuiValidatorSummary } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -12,7 +12,7 @@ import type { SuiValidatorSummaryWithApy } from '../../pages/home/home/dapp/dapp
 const DEFAULT_APY_DECIMALS = 2;
 
 export interface ApyWithValidatorMap {
-    [validatorAddress: SuiAddress]: SuiValidatorSummaryWithApy;
+    [validatorAddress: string]: SuiValidatorSummaryWithApy;
 }
 
 // For small APY or epoch before stakeSubsidyStartEpoch, show ~0% instead of 0%

--- a/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiAddress } from '@mysten/sui.js';
-
 import { getHumanReadable } from '../helpers/transactions';
 import analyzeTransactions from '../helpers/transactions/analyzeTransactions';
 import sortUniqueTransactions from '../helpers/transactions/sortUniqueTransactions';
 import { api } from '_redux/store/thunk-extras';
 
 export const queryTransactionsByAddress = async (
-    address: SuiAddress,
+    address: string,
     cursorTo?: string,
     cursorFrom?: string,
     limit?: number

--- a/src/ui/app/hooks/useWalletOrContact.ts
+++ b/src/ui/app/hooks/useWalletOrContact.ts
@@ -1,8 +1,6 @@
 import useAppSelector from './useAppSelector';
 
-import type { SuiAddress } from '@mysten/sui.js';
-
-const useWalletOrContact = (address: SuiAddress) => {
+const useWalletOrContact = (address: string) => {
     return useAppSelector(({ account, contacts }) => {
         const accountInfos = account.accountInfos;
         const contactsInfos = contacts.contacts;

--- a/src/ui/app/pages/dapp-tx-approval/lib/analyzeChanges.ts
+++ b/src/ui/app/pages/dapp-tx-approval/lib/analyzeChanges.ts
@@ -5,7 +5,6 @@ import addressOwner from '_src/ui/app/helpers/transactions/addressOwner';
 
 import type {
     RawSigner,
-    SuiAddress,
     SuiObjectChange,
     TransactionBlock,
 } from '@mysten/sui.js';
@@ -44,7 +43,7 @@ export type BalanceAddition = {
 };
 
 export type AnalyzeChangesResult = {
-    owner: SuiAddress;
+    owner: string;
     blockData?: TransactionBlock['blockData'];
     moveCalls: TransactionBlock['blockData']['transactions'];
     dryRunResponse: DryRunTransactionBlockResponse;
@@ -69,7 +68,7 @@ const getTotalGasUsed = (
 };
 
 const assetChanges = (
-    address: SuiAddress,
+    address: string,
     objectChanges: SuiObjectChange[]
 ) => {
     const transfers = objectChanges.filter(
@@ -95,7 +94,7 @@ const assetChanges = (
 };
 
 const coinChanges = (
-    address: SuiAddress,
+    address: string,
     { balanceChanges, effects }: DryRunTransactionBlockResponse
 ) => {
     const gasUsed = getTotalGasUsed(effects);

--- a/src/ui/app/pages/dapp-tx-approval/lib/owner.ts
+++ b/src/ui/app/pages/dapp-tx-approval/lib/owner.ts
@@ -1,5 +1,3 @@
-import type { SuiAddress } from '@mysten/sui.js';
-
 export type Owner =
     | {
           AddressOwner: string;
@@ -14,7 +12,7 @@ export type Owner =
       }
     | 'Immutable';
 
-const owner = (owner?: Owner, you?: SuiAddress) => {
+const owner = (owner?: Owner, you?: string) => {
     if (!owner) return 'Immutable';
     if (typeof owner === 'string') return owner;
     if ('AddressOwner' in owner) {

--- a/src/ui/app/pages/dapp-tx-approval/types/Amount.tsx
+++ b/src/ui/app/pages/dapp-tx-approval/types/Amount.tsx
@@ -9,7 +9,7 @@ import { useFormatCoin } from '_src/ui/app/hooks';
 import Body from '_src/ui/app/shared/typography/Body';
 
 import type { BalanceReduction, BalanceAddition } from '../lib/analyzeChanges';
-import type { SuiAddress, SuiObjectChange } from '@mysten/sui.js';
+import type { SuiObjectChange } from '@mysten/sui.js';
 
 export const Costs = ({
     balanceReductions,
@@ -63,7 +63,7 @@ export const Sending = ({
     owner,
     transfers,
 }: {
-    owner: SuiAddress;
+    owner: string;
     transfers: SuiObjectChange[];
 }) => {
     const sending = transfers.filter(
@@ -88,7 +88,7 @@ export const Receiving = ({
     owner,
     transfers,
 }: {
-    owner: SuiAddress;
+    owner: string;
     transfers: SuiObjectChange[];
 }) => {
     const receiving = transfers.filter(

--- a/src/ui/app/pages/dapp-tx-approval/types/Base.tsx
+++ b/src/ui/app/pages/dapp-tx-approval/types/Base.tsx
@@ -18,7 +18,6 @@ import type { Section } from '../SectionElement';
 import type { SmallDetail } from '../SmallValue';
 import type {
     RawSigner,
-    SuiAddress,
     SuiObjectChange,
     TransactionEffects,
 } from '@mysten/sui.js';
@@ -43,7 +42,7 @@ export type BaseProps = {
     transactionBlock: TransactionBlock | null;
     objectChanges?: SuiObjectChange[] | null;
     effects?: TransactionEffects | null;
-    address: SuiAddress | null;
+    address: string | null;
     setDone: (done: boolean) => void;
 };
 

--- a/src/ui/app/pages/dapp-tx-approval/types/Details.tsx
+++ b/src/ui/app/pages/dapp-tx-approval/types/Details.tsx
@@ -16,7 +16,7 @@ import type {
     AnalyzeChangesResult,
     GasCostSummary,
 } from '../lib/analyzeChanges';
-import type { RawSigner, SuiAddress, SuiObjectChange } from '@mysten/sui.js';
+import type { RawSigner, SuiObjectChange } from '@mysten/sui.js';
 import type { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 import type { LedgerSigner } from '_src/shared/cryptography/LedgerSigner';
 import type { ReactNode } from 'react';
@@ -87,7 +87,7 @@ const BalanceChanges = ({
     address,
 }: {
     analysis: AnalyzeChangesResult;
-    address?: SuiAddress;
+    address?: string;
 }) => {
     if (analysis.dryRunResponse.balanceChanges.length === 0) return null;
 
@@ -143,7 +143,7 @@ const AssetChanges = ({
     address,
 }: {
     analysis: AnalyzeChangesResult;
-    address?: SuiAddress;
+    address?: string;
 }) => {
     if (analysis.dryRunResponse.objectChanges.length === 0) return <></>;
 
@@ -278,7 +278,7 @@ const Details = ({
 }) => {
     const { resolvedTheme } = useTheme();
     const [details, setDetails] = useState(false);
-    const [address, setAddress] = useState<SuiAddress | undefined>(undefined);
+    const [address, setAddress] = useState<string | undefined>(undefined);
 
     useEffect(() => {
         signer.getAddress().then(setAddress);

--- a/src/ui/app/pages/home/home/dapp/dapps/AddressBook/ContactForm.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/AddressBook/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { isValidSuiAddress } from '@mysten/sui.js';
+import { isValidSuiAddress } from '@mysten/sui.js/utils';
 import { useField } from 'formik';
 import { useState, useCallback } from 'react';
 import * as Yup from 'yup';
@@ -9,8 +9,6 @@ import Input from '_src/ui/app/shared/inputs/Input';
 import ColorPickerMenu from '_src/ui/app/shared/inputs/colors/ColorPickerMenu';
 import EmojiPickerMenu from '_src/ui/app/shared/inputs/emojis/EmojiPickerMenu';
 import BodyLarge from '_src/ui/app/shared/typography/BodyLarge';
-
-import type { SuiAddress } from '@mysten/sui.js';
 
 export const addressValidation = Yup.string()
     .ensure()
@@ -27,7 +25,7 @@ export const nameValidation = Yup.string().required('Enter a name');
 
 interface ContactFormProps {
     name?: string;
-    address?: SuiAddress;
+    address?: string;
     emoji?: string;
     setEmoji: React.Dispatch<React.SetStateAction<string | undefined>>;
     color: string;

--- a/src/ui/app/pages/home/home/dapp/dapps/AddressBook/ContactPage/AddressTooltip.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/AddressBook/ContactPage/AddressTooltip.tsx
@@ -5,11 +5,10 @@ import { toast } from 'react-toastify';
 import { SuccessAlert } from '_src/ui/app/shared/alerts/SuccessAlert';
 import Body from '_src/ui/app/shared/typography/Body';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { ReactNode } from 'react';
 
 interface AddressTooltipProps {
-    address: SuiAddress;
+    address: string;
     children: ReactNode;
 }
 

--- a/src/ui/app/pages/home/home/dapp/dapps/Staking/ExistingStake.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/Staking/ExistingStake.tsx
@@ -3,7 +3,6 @@ import { CircleStackIcon } from '@heroicons/react/24/solid';
 import {
     SUI_TYPE_ARG,
     type DelegatedStake,
-    type SuiAddress,
 } from '@mysten/sui.js';
 import classNames from 'classnames';
 import { type PropsWithChildren, useCallback, useMemo } from 'react';
@@ -29,7 +28,7 @@ export interface Stake {
 }
 
 export interface StakeWithValidatorAddress extends Stake {
-    validatorAddress: SuiAddress;
+    validatorAddress: string;
 }
 
 interface ExistingStakeProps {

--- a/src/ui/app/pages/home/home/dapp/dapps/Staking/SelectValidator.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/Staking/SelectValidator.tsx
@@ -7,16 +7,14 @@ import Button from '_src/ui/app/shared/buttons/Button';
 import EthosLink from '_src/ui/app/shared/typography/EthosLink';
 import Subheader from '_src/ui/app/shared/typography/Subheader';
 
-import type { SuiAddress } from '@mysten/sui.js';
-
 const SelectValidator: React.FC = () => {
     const navigate = useNavigate();
     const [selectedValidator, setSelectedValidator] = useState<
-        SuiAddress | undefined
+        string | undefined
     >();
 
     const onSelectValidator = useCallback(
-        (validatorAddress: SuiAddress) => {
+        (validatorAddress: string) => {
             setSelectedValidator(validatorAddress);
         },
         [setSelectedValidator]

--- a/src/ui/app/pages/home/home/dapp/dapps/Staking/StakeDetail.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/Staking/StakeDetail.tsx
@@ -30,14 +30,12 @@ import ConfirmDestructiveActionDialog from '_src/ui/app/shared/dialog/ConfirmDes
 import Body from '_src/ui/app/shared/typography/Body';
 import BodyLarge from '_src/ui/app/shared/typography/BodyLarge';
 
-import type { SuiAddress } from '@mysten/sui.js';
-
 const APY_HELP_TEXT =
     "Annualized Percentage Yield of validator's past operations. Note, there is no guarantee APY will true indefinitely";
 const COMMISSION_HELP_TEXT =
     'Fee charged against earned rewards by the validator for staking services';
 
-function revokeStakeTransaction(stakedSuiId: SuiAddress) {
+function revokeStakeTransaction(stakedSuiId: string) {
     const tx = new TransactionBlock();
     tx.moveCall({
         target: '0x3::sui_system::request_withdraw_stake',

--- a/src/ui/app/pages/home/home/dapp/dapps/Staking/ValidatorList.tsx
+++ b/src/ui/app/pages/home/home/dapp/dapps/Staking/ValidatorList.tsx
@@ -9,7 +9,7 @@ import ArrowUpDownSort from '_src/ui/app/shared/svg/ArrowUpDownSort';
 import Body from '_src/ui/app/shared/typography/Body';
 import EthosLink from '_src/ui/app/shared/typography/EthosLink';
 
-import type { SuiAddress, SuiValidatorSummary } from '@mysten/sui.js';
+import type { SuiValidatorSummary } from '@mysten/sui.js';
 
 export interface SuiValidatorSummaryWithApy extends SuiValidatorSummary {
     apy: number;
@@ -18,8 +18,8 @@ export interface SuiValidatorSummaryWithApy extends SuiValidatorSummary {
 }
 
 interface ValidatorListProps {
-    onSelectValidator: (string: SuiAddress) => void;
-    selectedValidator?: SuiAddress;
+    onSelectValidator: (string: string) => void;
+    selectedValidator?: string;
 }
 
 export type SortDirection = 'asc' | 'desc';
@@ -113,7 +113,7 @@ const ValidatorList: React.FC<ValidatorListProps> = ({
 
 interface ValidatorRowProps {
     validator: SuiValidatorSummaryWithApy;
-    onSelect: (suiAddress: SuiAddress) => void;
+    onSelect: (suiAddress: string) => void;
     isSelected: boolean;
 }
 

--- a/src/ui/app/redux/slices/account/index.ts
+++ b/src/ui/app/redux/slices/account/index.ts
@@ -4,7 +4,6 @@
 import { fromHEX } from '@mysten/bcs';
 import {
     Ed25519Keypair,
-    type SuiAddress,
     type SuiMoveObject,
 } from '@mysten/sui.js';
 import {
@@ -1193,7 +1192,7 @@ export type AccountState = {
     passphrase: string | null;
     creating: boolean;
     createdMnemonic: string | null;
-    address: SuiAddress | null;
+    address: string | null;
     accountInfos: AccountInfo[];
     activeAccountIndex: number;
     accountType: AccountType;

--- a/src/ui/app/redux/slices/contacts.ts
+++ b/src/ui/app/redux/slices/contacts.ts
@@ -2,11 +2,10 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { getEncrypted, setEncrypted } from '_src/shared/storagex/store';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 export interface Contact {
-    address: SuiAddress;
+    address: string;
     nickname: string;
     emoji?: string;
     color: string;

--- a/src/ui/app/redux/slices/permissions/index.ts
+++ b/src/ui/app/redux/slices/permissions/index.ts
@@ -7,7 +7,6 @@ import {
     createSlice,
 } from '@reduxjs/toolkit';
 
-import type { SuiAddress } from '@mysten/sui.js';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { Permission } from '_messages/payloads/permissions';
 import type { RootState } from '_redux/RootReducer';
@@ -24,11 +23,11 @@ const permissionsAdapter = createEntityAdapter<Permission>({
 export const respondToPermissionRequest = createAsyncThunk<
     {
         id: string;
-        accounts: SuiAddress[];
+        accounts: string[];
         allowed: boolean;
         responseDate: string;
     },
-    { id: string; accounts: SuiAddress[]; allowed: boolean },
+    { id: string; accounts: string[]; allowed: boolean },
     AppThunkConfig
 >(
     'respond-to-permission-request',


### PR DESCRIPTION
This PR is doing a very simple thing in a lot of places. `SuiAddress` type is deprecated and they recommend replacing it with the `string` type. That's what this does.