### PR TITLE
remove Connection and JsonRPCProvider

### DIFF
--- a/src/background/Transactions.ts
+++ b/src/background/Transactions.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    Connection,
     Ed25519Keypair,
     RawSigner,
 } from '@mysten/sui.js';
@@ -311,20 +310,20 @@ class Transactions {
             envEndpoint = envInfo?.sui_Env_RPC;
         }
 
-        let connection: Connection;
+        let url: string;
         if (envEndpoint) {
-            connection = new Connection({ fullnode: envEndpoint });
+            url = envEndpoint
         } else if (env) {
-            connection = api.getEndPoints(env);
+            url = api.getEndPoints(env);
         } else {
             throw new Error('No connection found');
         }
 
-        if (!connection) {
-            throw new Error('No connection found');
+        if (!url) {
+            throw new Error('No url found with which to establish a SuiClient connection');
         }
 
-        const client = new SuiClient({ url: connection.fullnode });
+        const client = new SuiClient({ url });
 
         try {
             let signer;

--- a/src/ui/app/ApiProvider.ts
+++ b/src/ui/app/ApiProvider.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Connection, RawSigner } from '@mysten/sui.js';
+import { RawSigner } from '@mysten/sui.js';
 import { SuiClient } from '@mysten/sui.js/client';
+import { getFaucetHost } from '@mysten/sui.js/faucet';
 
 import { EthosSigner } from '_src/shared/cryptography/EthosSigner';
 
@@ -29,63 +30,35 @@ export const API_ENV_TO_INFO: Record<string, EnvInfo> = {
     [API_ENV.customRPC.toString()]: { name: 'Custom RPC URL' },
 };
 
-export const ENV_TO_API: Record<string, Connection | null> = {
-    [API_ENV.mainNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_MAINNET_FULLNODE || '',
-        faucet: '',
-    }),
-    [API_ENV.testNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_TESTNET_FULLNODE || '',
-        faucet: process.env.API_ENDPOINT_TESTNET_FAUCET || '',
-    }),
-    [API_ENV.devNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_DEVNET_FULLNODE || '',
-        faucet: process.env.API_ENDPOINT_DEVNET_FAUCET || '',
-    }),
-    [API_ENV.local.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_LOCAL_FULLNODE || '',
-        faucet: process.env.API_ENDPOINT_LOCAL_FAUCET || '',
-    }),
+export const ENV_TO_API: Record<string, string | null> = {
+    [API_ENV.mainNet.toString()]:
+        process.env.API_ENDPOINT_MAINNET_FULLNODE || '',
+    [API_ENV.testNet.toString()]:
+        process.env.API_ENDPOINT_TESTNET_FULLNODE || '',
+    [API_ENV.devNet.toString()]: process.env.API_ENDPOINT_DEVNET_FULLNODE || '',
+    [API_ENV.local.toString()]: process.env.API_ENDPOINT_LOCAL_FULLNODE || '',
     [API_ENV.customRPC.toString()]: null,
 };
 
-export const ENV_TO_API_2: Record<string, Connection | null> = {
-    [API_ENV.mainNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_MAINNET_FULLNODE_2 || '',
-        faucet: '',
-    }),
-    [API_ENV.testNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_TESTNET_FULLNODE_2 || '',
-        faucet: process.env.API_ENDPOINT_TESTNET_FAUCET || '',
-    }),
-    [API_ENV.devNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_DEVNET_FULLNODE_2 || '',
-        faucet: process.env.API_ENDPOINT_DEVNET_FAUCET || '',
-    }),
-    [API_ENV.local.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_LOCAL_FULLNODE_2 || '',
-        faucet: process.env.API_ENDPOINT_LOCAL_FAUCET || '',
-    }),
+export const ENV_TO_API_2: Record<string, string | null> = {
+    [API_ENV.mainNet.toString()]:
+        process.env.API_ENDPOINT_MAINNET_FULLNODE_2 || '',
+    [API_ENV.testNet.toString()]:
+        process.env.API_ENDPOINT_TESTNET_FULLNODE_2 || '',
+    [API_ENV.devNet.toString()]:
+        process.env.API_ENDPOINT_DEVNET_FULLNODE_2 || '',
+    [API_ENV.local.toString()]: process.env.API_ENDPOINT_LOCAL_FULLNODE_2 || '',
     [API_ENV.customRPC.toString()]: null,
 };
 
-export const ENV_TO_API_3: Record<string, Connection | null> = {
-    [API_ENV.mainNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_MAINNET_FULLNODE_3 || '',
-        faucet: '',
-    }),
-    [API_ENV.testNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_TESTNET_FULLNODE_3 || '',
-        faucet: process.env.API_ENDPOINT_TESTNET_FAUCET || '',
-    }),
-    [API_ENV.devNet.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_DEVNET_FULLNODE_3 || '',
-        faucet: process.env.API_ENDPOINT_DEVNET_FAUCET || '',
-    }),
-    [API_ENV.local.toString()]: new Connection({
-        fullnode: process.env.API_ENDPOINT_LOCAL_FULLNODE_3 || '',
-        faucet: process.env.API_ENDPOINT_LOCAL_FAUCET || '',
-    }),
+export const ENV_TO_API_3: Record<string, string | null> = {
+    [API_ENV.mainNet.toString()]:
+        process.env.API_ENDPOINT_MAINNET_FULLNODE_3 || '',
+    [API_ENV.testNet.toString()]:
+        process.env.API_ENDPOINT_TESTNET_FULLNODE_3 || '',
+    [API_ENV.devNet.toString()]:
+        process.env.API_ENDPOINT_DEVNET_FULLNODE_3 || '',
+    [API_ENV.local.toString()]: process.env.API_ENDPOINT_LOCAL_FULLNODE_3 || '',
     [API_ENV.customRPC.toString()]: null,
 };
 
@@ -97,7 +70,7 @@ function getDefaultAPI(env: API_ENV, fallbackNumber?: number) {
     //     {} as Record<string, Record<string, string>>
     // );
 
-    const dynamicApiEnvs = {} as Record<string, Record<string, string>>;
+    const dynamicApiEnvs = {} as Record<string, string>;
 
     let mergedApiEnvs = ENV_TO_API;
 
@@ -109,26 +82,13 @@ function getDefaultAPI(env: API_ENV, fallbackNumber?: number) {
 
     for (const env of Object.keys(ENV_TO_API)) {
         if (dynamicApiEnvs[env]) {
-            mergedApiEnvs[env] = new Connection({
-                fullnode:
-                    dynamicApiEnvs[env]?.fullnode ||
-                    ENV_TO_API[env]?.fullnode ||
-                    '',
-                faucet:
-                    dynamicApiEnvs[env]?.faucet ||
-                    ENV_TO_API[env]?.faucet ||
-                    '',
-                websocket:
-                    dynamicApiEnvs[env]?.websocket ||
-                    ENV_TO_API[env]?.websocket ||
-                    '',
-            });
+            mergedApiEnvs[env] = dynamicApiEnvs[env] || ENV_TO_API[env] || '';
         }
     }
 
     const apiEndpoint = mergedApiEnvs[env];
 
-    if (!apiEndpoint || apiEndpoint.fullnode === '') {
+    if (!apiEndpoint) {
         throw new Error(`API endpoint not found for API_ENV ${env}`);
     }
     return apiEndpoint;
@@ -152,27 +112,28 @@ export default class ApiProvider {
     private _apiFullNodeClient?: SuiClient;
     private _signer: RawSigner | null = null;
     private _apiEnv: API_ENV = DEFAULT_API_ENV;
-    private _customRPC: string | null = null;
-    private _connection: Connection | null = null;
+    private _customUrl: string | null = null;
 
     public setNewSuiClient(
         apiEnv: API_ENV = DEFAULT_API_ENV,
         fallbackNumber?: number,
-        customRPC?: string | null,
+        customUrl?: string | null,
         queryClient?: QueryClient
     ) {
         this._apiEnv = apiEnv;
         this.fallbackNumber = fallbackNumber;
-        this._customRPC = customRPC ?? null;
+        this._customUrl = customUrl ?? null;
 
         // Make sure that state is cleared when switching networks
         queryClient?.clear();
 
-        this._connection = customRPC
-            ? new Connection({ fullnode: customRPC })
+        const url = customUrl
+            ? customUrl
             : getDefaultAPI(apiEnv, this.fallbackNumber);
 
-        this._apiFullNodeClient = new SuiClient({url: this._connection.fullnode});
+        this._apiFullNodeClient = new SuiClient({
+            url,
+        });
 
         this._signer = null;
     }
@@ -190,9 +151,20 @@ export default class ApiProvider {
         this.setNewSuiClient(
             this._apiEnv,
             (this.fallbackNumber ?? 1) + 1,
-            this._customRPC
+            this._customUrl
         );
         return true;
+    }
+
+    public get faucetUrl() {
+        const networkName = this._apiEnv.toLowerCase();
+        if (
+            networkName === 'testnet' ||
+            networkName === 'devnet' ||
+            networkName === 'localnet'
+        ) {
+            return getFaucetHost(networkName);
+        } else return '';
     }
 
     public get instance() {
@@ -200,12 +172,14 @@ export default class ApiProvider {
             this.setNewSuiClient(
                 this._apiEnv,
                 this.fallbackNumber,
-                this._customRPC
+                this._customUrl
             );
         }
         return {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            fullNode: this._connection?.fullnode,
+            fullNode: this._customUrl
+                ? this._customUrl
+                : getDefaultAPI(this._apiEnv, this.fallbackNumber),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             client: this._apiFullNodeClient!,
         };
@@ -216,7 +190,7 @@ export default class ApiProvider {
             this.setNewSuiClient(
                 this._apiEnv,
                 this.fallbackNumber,
-                this._customRPC
+                this._customUrl
             );
         }
 
@@ -238,7 +212,7 @@ export default class ApiProvider {
             this.setNewSuiClient(
                 this._apiEnv,
                 this.fallbackNumber,
-                this._customRPC
+                this._customUrl
             );
         }
         return new EthosSigner(

--- a/src/ui/app/shared/buttons/SendReceiveButtonGroup.tsx
+++ b/src/ui/app/shared/buttons/SendReceiveButtonGroup.tsx
@@ -56,7 +56,7 @@ const SendReceiveButtonGroup = ({
     const _faucet = useCallback(() => {
         setIsFaucetInProgress(true);
         const faucet = async () => {
-            const result = await fetch(`${api.getEndPoints().faucet}gas`, {
+            const result = await fetch(`${api.faucetUrl}gas`, {
                 method: 'POST',
                 headers: {
                     Accept: 'application/json',


### PR DESCRIPTION
This code replaces the `Connection` object with a url string, and various places that relied on `Connection` details needed to be rehandled, particularly, the `ApiProvider`.

This changeset depends on the changes in `ag/deprecations` so merge into that branch, or, merge into main after you merge `ag/deprecations` into main.